### PR TITLE
ngIRCd build recipe

### DIFF
--- a/ngircd/Makefile
+++ b/ngircd/Makefile
@@ -1,0 +1,61 @@
+include ../Makefile.inc
+
+UPSTREAM = https://github.com/ngircd/ngircd/archive/rel-22.1.tar.gz
+
+NGIRCD_CONF_OPTS += \
+	--without-pam
+
+
+
+all: bin/ngircd images/data/conf/ngircd.conf images/data/conf/Commands.txt
+
+
+
+# avoid warnings, configure the unprivileged user
+images/data/conf/ngircd.conf: build/autogen.sh
+	mkdir -p images/data/conf
+	cp build/doc/sample-ngircd.conf.tmpl $@
+	sed -e 's#;HelpFile = :DOCDIR:/Commands.txt#HelpFile = /data/Commands.txt#' $@ > $@.tmp && mv $@.tmp $@
+	sed -e 's#;MotdPhrase = "Hello world!"#MotdPhrase = "IRC server running on a rump kernel!"#' $@ > $@.tmp && mv $@.tmp $@
+	sed -e 's#;ServerGID = 65534#ServerGID = 1#' $@ > $@.tmp && mv $@.tmp $@
+	sed -e 's#;ServerUID = 65534#ServerUID = 1#' $@ > $@.tmp && mv $@.tmp $@
+
+images/data/conf/Commands.txt: images/data/conf/ngircd.conf
+	cp build/doc/Commands.txt $@
+
+
+
+bin/ngircd: build/src/ngircd/ngircd
+	mkdir -p bin
+	cp $< $@
+
+build/src/ngircd/ngircd: build/Makefile
+	-$(MAKE) -C build
+
+# aclocal needed to generate the configure script
+build/Makefile: build/autogen.sh
+	(cd build; ./autogen.sh && ./configure --host=$(RUMPRUN_TOOLCHAIN_TUPLE) $(NGIRCD_CONF_OPTS))
+
+build/autogen.sh:
+	mkdir -p build
+	../scripts/fetch.sh $(UPSTREAM) build/ngircd.tar.gz
+	tar --strip-components 1 -x -C build -f build/ngircd.tar.gz
+
+
+
+.PHONY: images
+images: images/data.iso images/stubetc.iso
+
+images/stubetc.iso: ../stubetc/etc
+	genisoimage -l -r -o images/stubetc.iso $<
+
+images/data.iso: images/data/conf/ngircd.conf images/data/conf/Commands.txt
+	genisoimage -l -r -o images/data.iso $^
+
+
+
+.PHONY: clean
+clean:
+	-$(MAKE) -C build clean
+	rm -f bin/ngircd
+	rm -f images/stubetc.iso images/data.iso

--- a/ngircd/README.md
+++ b/ngircd/README.md
@@ -1,0 +1,53 @@
+Overview
+========
+
+Packaging of unmodified [ngircd](http://ngircd.barton.de/) 22.1.
+
+ngIRCd is "a free, portable and lightweight Internet Relay Chat server for small
+or private networks".
+
+Patches
+=======
+
+None required.
+
+Instructions
+============
+
+The configuration script needs to be generated so `aclocal` is needed.  
+The build script also requires `genisoimage` in order to build the ISO images
+for `/data` and `/etc`.
+
+Run `make` to build ngIRCd:
+```
+make
+```
+
+Bake the final unikernel image:
+```
+rumpbake xen_pv bin/ngircd.bin bin/ngircd
+```
+(Replace `xen_pv` with the platform you are baking for.)
+
+You may want to edit the example configuration that will be put in
+`images/data/conf/` directory after a successful `make` (for example,
+to change the server name, to setup the administrative informations that are
+required by RFC, to add some default channels, etc).  
+Once this is done you can create the ISO images with:
+```
+make images
+```
+
+Examples
+========
+
+To start a Xen domU running ngIRCd, as root run (for example):
+````
+rumprun xen -M 128 -di \
+    -n inet,static,10.10.10.10/24 \
+    -b images/stubetc.iso,/etc \
+    -b images/data.iso,/data \
+    -- bin/ngircd.bin --config /data/ngircd.conf --nodaemon
+````
+The `--nodaemon` option is required to avoid ngIRCd calling `fork()`.  
+Replace `10.10.10.10/24` with a valid IP address on your Xen network.


### PR DESCRIPTION
Hi,

This pull request adds a simple Makefile to build an unmodified ngIRCd (an IRC server) and a README.md.
There is two build steps, so the user can modify the provided configuration:
- `make` to build ngIRCd binary and create a basic configuration,
- `make images` to build the ISO images.

I'm quite unhappy with the `sed` in the Makefile, but it gets the job done (I avoided the unportable '-i' option):
- setting the MotdPhrase removes a warning and avoid to add a motd file,
- setting the HelpFile also removes a warning and tell ngIRCd to use that one,
- setting the UID & GID are necessary so ngIRCd can start (or it will try to use the 'nobody' user (uid 65534)).

ngIRCd will complain about the missing, but required by the RFC, administrator informations but I think we can leave that to the user (and setting up some basic stuff like the server name).
