### PR TITLE
ngIRCd build with SSL support

### DIFF
--- a/ngircd/Makefile
+++ b/ngircd/Makefile
@@ -3,7 +3,9 @@ include ../Makefile.inc
 UPSTREAM = https://github.com/ngircd/ngircd/archive/rel-22.1.tar.gz
 
 NGIRCD_CONF_OPTS += \
-	--without-pam
+	--without-pam \
+	--enable-ipv6 \
+	--with-openssl
 
 
 
@@ -15,7 +17,7 @@ all: bin/ngircd images/data/conf/ngircd.conf images/data/conf/Commands.txt
 images/data/conf/ngircd.conf: build/autogen.sh
 	mkdir -p images/data/conf
 	cp build/doc/sample-ngircd.conf.tmpl $@
-	sed -e 's#;HelpFile = :DOCDIR:/Commands.txt#HelpFile = /data/Commands.txt#' $@ > $@.tmp && mv $@.tmp $@
+	sed -e 's#;HelpFile = :DOCDIR:/Commands.txt#HelpFile = /data/conf/Commands.txt#' $@ > $@.tmp && mv $@.tmp $@
 	sed -e 's#;MotdPhrase = "Hello world!"#MotdPhrase = "IRC server running on a rump kernel!"#' $@ > $@.tmp && mv $@.tmp $@
 	sed -e 's#;ServerGID = 65534#ServerGID = 1#' $@ > $@.tmp && mv $@.tmp $@
 	sed -e 's#;ServerUID = 65534#ServerUID = 1#' $@ > $@.tmp && mv $@.tmp $@
@@ -50,7 +52,7 @@ images/stubetc.iso: ../stubetc/etc
 	genisoimage -l -r -o images/stubetc.iso $<
 
 images/data.iso: images/data/conf/ngircd.conf images/data/conf/Commands.txt
-	genisoimage -l -r -o images/data.iso $^
+	genisoimage -l -r -o images/data.iso images/data
 
 
 

--- a/ngircd/README.md
+++ b/ngircd/README.md
@@ -43,11 +43,15 @@ Examples
 
 To start a Xen domU running ngIRCd, as root run (for example):
 ````
-rumprun xen -M 128 -di \
+rumprun xen -M 32 -di \
     -n inet,static,10.10.10.10/24 \
     -b images/stubetc.iso,/etc \
     -b images/data.iso,/data \
-    -- bin/ngircd.bin --config /data/ngircd.conf --nodaemon
+    -- bin/ngircd.bin --config /data/conf/ngircd.conf --nodaemon
 ````
 The `--nodaemon` option is required to avoid ngIRCd calling `fork()`.  
 Replace `10.10.10.10/24` with a valid IP address on your Xen network.
+
+If SSL is needed, ngIRCd is build with OpenSSL support. You can follow a quick
+how-to on the [official site](http://ngircd.barton.de/doc/SSL.txt) to known how
+to configure ngIRCd for SSL and create a self-signed certificate.


### PR DESCRIPTION
Hi,

Sorry for this second pull request but I did not know that OpenSSL was provided by default.

This patch mainly adds SSL support to ngIRCd,
It also enables IPv6 and modifies the data.iso image to have a `conf` directory (so it is similar with the others build recipes).
