### PR TITLE
 Readme command line update

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -78,7 +78,7 @@ rumpbake hw_generic a.bin a.out
 To launch, `rumprun` it:
 
 ```
-rumprun kvm -i -b python.iso,/python/lib/python3.4 -b stubetc.iso,/etc -e PYTHONHOME=/python a.bin
+rumprun kvm -i -b python.iso,/python/lib/python3.4 -b stubetc.iso,/etc -e PYTHONHOME=/python -e HOME=/ a.bin
 ```
 
 You should see the helloworld text printed.


### PR DESCRIPTION
Without HOME defined in the environment, getpwuid() dies when trying to expand the user because there are no user entries in the rump kernel environment. The user will get an error:

`KeyError: getpwuid(): uid not found: 0`

https://github.com/python/cpython/blob/3.3/Lib/posixpath.py#L259-L263
