### PR TITLE
Erlang now available on rumprun

### DIFF
--- a/erlang/.gitignore
+++ b/erlang/.gitignore
@@ -1,0 +1,6 @@
+build/
+dl/
+images/*.iso
+
+*.beam
+examples/app.iso

--- a/erlang/Makefile
+++ b/erlang/Makefile
@@ -1,0 +1,88 @@
+include ../Makefile.inc
+
+PKG_VERSION=18.0
+UPSTREAM=http://www.erlang.org/download/otp_src_$(PKG_VERSION).tar.gz
+TARBALL=$(notdir $(UPSTREAM))
+ARCH=$(shell $(RUMPRUN_CC) -dumpmachine)
+RUMP_INSTALL_LOCATION=/opt/erlang
+
+LOCAL_INSTALL_DESTINATION=$(shell pwd)/build/erlangdist
+
+# use "make V=1" for getting verbose build of erlang, which
+# is very useful for debugging build issues
+ifneq ($(V), 1)
+  V=0
+endif
+
+all: build/erlang examples images
+
+build/erlang: build/Makefile
+	$(MAKE) -C build V=$(V)
+	$(MAKE) -C build V=$(V) DESTDIR=$(LOCAL_INSTALL_DESTINATION) install
+
+ERLANG_CONF_OPTS += \
+	--prefix=$(RUMP_INSTALL_LOCATION) \
+	--disable-shared \
+	--host=$(RUMPRUN_TOOLCHAIN_TUPLE) \
+	--build=$(ARCH) \
+	erl_xcomp_sysroot=$(RUMPRUN_SYSROOT) \
+	--without-termcap \
+	--without-odbc \
+	--without-wx \
+	--disable-shared \
+	--enable-static \
+	--disable-dynamic-ssl-lib
+
+build/Makefile: build/bootstrap_complete
+	(cd build; ./configure $(ERLANG_CONF_OPTS))
+	mkdir -p bin
+	cp build/bin/$(RUMPRUN_TOOLCHAIN_TUPLE)/beam bin/
+
+build/bootstrap_complete: build/stamp_patch build/configure
+	(cd build; ./configure --enable-bootstrap-only)
+	(cd build; make)
+	touch $@
+
+# only needed when building from a git repo
+build/configure: build/stamp_patch
+	(cd build; ./otp_build autoconf)
+
+build/stamp_patch: build/untar_sources patches/*
+	(cd build && ../../scripts/apply-patches.sh ./ ../patches/*)
+	touch $@
+
+dl/$(TARBALL):
+	mkdir -p dl
+	../scripts/fetch.sh ${UPSTREAM} dl/$(TARBALL)
+
+build/untar_sources: | dl/$(TARBALL)
+	mkdir -p build
+	(cd build && tar -x --strip-components 1 -f ../dl/$(TARBALL))
+	touch $@
+
+examples: examples/app.iso
+
+examples/app.iso:
+	$(MAKE) -C examples all
+
+.PHONY: images
+images: images/erlang.iso
+
+
+images/erlang.iso: build/Makefile
+	mkdir -p images
+	cp erl_inetrc build/erlangdist/$(RUMP_INSTALL_LOCATION)/
+	cp hosts.template build/erlangdist/$(RUMP_INSTALL_LOCATION)/hosts
+	genisoimage -l -r -o images/erlang.iso build/erlangdist/$(RUMP_INSTALL_LOCATION)
+
+.PHONY: clean
+clean:
+	-$(MAKE) -C build clean
+	rm -f bin/*
+	rm -f images/erlang.iso
+	rm -rf dl/
+	-$(MAKE) -C examples clean
+
+.PHONY: distclean
+distclean: clean
+	rm -rf build

--- a/erlang/README.md
+++ b/erlang/README.md
@@ -1,0 +1,156 @@
+Overview
+========
+
+This document will enable you to bake erlang on rumprun and launch
+it within qemu, while running in xen falls on the same lines.
+
+Patches
+=======
+
+The patches within the `patches/` sub-directory is primarily to get
+ssl working, although in future it'll host some optimizations as
+discussed in `Unoptimized Memory Allocation`_ subsection.
+
+Instructions
+============
+
+Run this `make` from a user account, *not the root account*. At the end of the
+installation, the Makefile will build two variants of the build. One is
+required for a host, so that the erlang code can be compiled on this
+host (.erl) to .beam. There is another one which can be baked for rumprun
+kernel.
+
+The build script requires `genisoimage` to create `erlang.iso` image.
+
+Run `make` from the erlang package directory:
+
+```
+cd rumprun-packages/erlang
+make
+```
+
+Examples
+========
+
+There are sample erlang applications (echoserver and helloworld) which can
+be built via the `make examples`. The details of the build are captured in
+the Makefile.
+
+```
+make examples
+```
+
+Next you'll need a baked image which can be run on qemu (or kvm or xen).
+
+The following build command will generate an image for non-smp, while using
+`hw` as the platform.
+
+```
+rumpbake hw_virtio beam.hw.bin bin/beam
+```
+
+The above can be either used in qemu or kvm. In case you
+want to use xen then the following commands can be used towards the same.
+
+> Note that the build commands in turn use *rumpbake* internally, so
+> be sure that you have built the appropriate platform for it
+> to work. Additionally rumpbake with xen_pv is used in the Makefile.
+
+```
+rumpbake xen_pv bin/beam.xen_pv.bin bin/beam
+```
+
+Now you've got a baked unikernel image.
+
+Setup the networking as follows (if not done already).
+
+```
+sudo ip tuntap add tap0 mode tap
+sudo ip addr add 10.0.120.100/24 dev tap0
+sudo ip link set dev tap0 up
+```
+
+You are now ready to run your first erlang unikernel. To run the rumpkernel using qemu, the following will work:
+
+```
+ERLAPP_PATH=/apps/erlang
+ERLHOME=/tmp
+ERLPATH=/opt/erlang
+rumprun qemu \
+   -I if,vioif,'-net tap,script=no,ifname=tap0' \
+   -W if,inet,static,10.0.120.101/24 \
+   -e ERL_INETRC=$ERLPATH/erl_inetrc \
+   -b images/erlang.iso,$ERLPATH \
+   -b examples/app.iso,$ERLAPP_PATH \
+   -i beam.hw.bin \
+     "-- -no_epmd -root $ERLPATH/lib/erlang -progname erl -- -home $ERLHOME -noshell -pa $ERLAPP_PATH -s echoserver start"
+```
+
+You should see `Echo server started` text printed to your screen.
+
+Now you can connect to the server via telnet as shown below:
+
+```
+$ telnet 10.0.120.101 8080
+Trying 10.0.120.101...
+Connected to 10.0.120.101.
+Escape character is '^]'.
+GET /
+GET /
+hello there!
+hello there!
+^]
+
+telnet> quit
+Connection closed.
+```
+
+You should replace `qemu` with `kvm` to run under kvm. For xen there will be
+equivalent variation and additionally use xen baked unikernel as well.
+
+Customizations
+==============
+
+The /opt/erlang
+---------------
+
+In case you want to change the /opt/erlang path then
+you'll have to change the Makefile, erl_inetrc and all
+the manual instructions mentioned in this document.
+
+Notes
+=====
+
+DNS
+---
+
+At present the erlang configuration inet configuration is tuned
+to use file and DNS as a source of resolving ip/host, though untested.
+
+Shortcomings
+============
+
+EPMD (clustering)
+-----------------
+
+In it's current form the epmd is not integrated within the baked
+image, so there is no support for clustering. Having said that it is
+not very difficult to hack together an image and get it working, but
+this is in the works at the time of this writing.
+
+
+Unoptimized Memory Allocation
+-----------------------------
+
+At present there is an unoptimal allocation of memory as a consequence of
+erlang alloc interacting with rumprun. This will be fixed in the near
+future, but something to be aware of in case you care. The exact amount
+of memory wasted is not quantified, because it needs to be fixed anyways.
+
+Unsupported SMP
+---------------
+
+SMP binary though available is useless, since rumprun doesn't support it.
+
+The rumpkernel supports SMP, but since rumprun won't support in the forceable
+future, so it wont't work.

--- a/erlang/erl_inetrc
+++ b/erlang/erl_inetrc
@@ -1,0 +1,9 @@
+%% -- ERLANG INET CONFIGURATION FILE --
+%% the hosts file
+{file, hosts, "/opt/erlang/hosts"}.
+%% enable EDNS, either comment it or set of false to disable it
+{edns,0}.
+%% cache_size default value is 100
+{cache_size, 50}.
+%% lookup method is both file and dns
+{lookup, [file, dns]}.

--- a/erlang/examples/Makefile
+++ b/erlang/examples/Makefile
@@ -1,0 +1,26 @@
+SUBDIRS=$(dir $(wildcard */Makefile))
+ERLFILES=$(wildcard */*.erl)
+BEAMFILES=$(patsubst %.erl, %.beam, $(ERLFILES))
+
+.PHONY: all
+
+all: app.iso
+
+app.iso: compile
+	mkdir -p app/modules
+	cp $(BEAMFILES) app/modules/
+	genisoimage -l -r -o app.iso app/modules/
+
+compile:
+	for dir in $(SUBDIRS); do \
+		$(MAKE) -C $$dir all; \
+	done
+
+.PHONY: clean
+
+clean:
+	for dir in $(SUBDIRS); do \
+		$(MAKE) -C $$dir $@; \
+	done
+	rm -rf app
+	rm -f app.iso

--- a/erlang/examples/Makefile.inc
+++ b/erlang/examples/Makefile.inc
@@ -1,0 +1,2 @@
+
+ERLC=../../build/bootstrap/bin/erlc

--- a/erlang/examples/echoserver/Makefile
+++ b/erlang/examples/echoserver/Makefile
@@ -1,0 +1,12 @@
+include ../Makefile.inc
+
+ERLFILES=$(wildcard *.erl)
+BEAMFILES=$(patsubst %.erl, %.beam, $(ERLFILES))
+
+all: $(BEAMFILES)
+
+%.beam: %.erl
+	$(ERLC) $<
+
+clean:
+	rm -f $(BEAMFILES)

--- a/erlang/examples/echoserver/echoserver.erl
+++ b/erlang/examples/echoserver/echoserver.erl
@@ -1,0 +1,35 @@
+%%%
+%%% A simple echo server
+%%%
+-module(echoserver).
+-author('Neeraj Sharma <neeraj.sharma@alumni.iitg.ernet.in>').
+-export([start/0]).
+
+-define(OPTIONS, [{active, false}, {reuseaddr, true}, {packet, 0}]).
+-define(PORT, 8080).
+
+
+start() ->
+    {ok, Socket} = gen_tcp:listen(?PORT, ?OPTIONS),
+    ListenHandler = spawn(fun() -> accept_a_connection(Socket) end),
+    gen_tcp:controlling_process(Socket, ListenHandler),
+    io:format("Echo server started~n").
+
+accept_a_connection(Socket) ->
+    {ok, ClientSocket} = gen_tcp:accept(Socket),
+    ChildPid = spawn(fun() -> handle_client_data(ClientSocket) end),
+    gen_tcp:controlling_process(ClientSocket, ChildPid),
+    accept_a_connection(Socket).
+
+handle_client_data(ClientSocket) ->
+    loop(ClientSocket).
+
+loop(ClientSocket) ->
+    case gen_tcp:recv(ClientSocket, 0) of
+        {ok, Data} -> handle_client_data(ClientSocket, Data),
+                      loop(ClientSocket);
+        {error, closed} -> ok
+    end.
+
+handle_client_data(ClientSocket, Data) ->
+    gen_tcp:send(ClientSocket, Data).

--- a/erlang/examples/helloworld/Makefile
+++ b/erlang/examples/helloworld/Makefile
@@ -1,0 +1,7 @@
+include ../Makefile.inc
+
+all:
+	$(ERLC) helloworld.erl
+
+clean:
+	rm -f *.beam

--- a/erlang/examples/helloworld/helloworld.erl
+++ b/erlang/examples/helloworld/helloworld.erl
@@ -1,0 +1,6 @@
+% hello world program
+-module(helloworld).
+-export([start/0]).
+
+start() ->
+      io:fwrite("Hello, world!\n").

--- a/erlang/hosts.template
+++ b/erlang/hosts.template
@@ -1,0 +1,9 @@
+#
+# hosts: static lookup table for host names
+#
+
+#<ip-address>	<hostname.domain.org>	<hostname>
+127.0.0.1	localhost.localdomain	localhost
+::1		localhost.localdomain	localhost
+
+# End of file

--- a/erlang/patches/erlonrump-18.0.patch
+++ b/erlang/patches/erlonrump-18.0.patch
@@ -1,0 +1,33 @@
+--- otp_src_18.0.orig/lib/crypto/c_src/Makefile.in	2015-06-24 00:26:21.000000000 +0530
++++ otp_src_18.0/lib/crypto/c_src/Makefile.in	2015-09-02 14:48:45.121950282 +0530
+@@ -127,10 +127,19 @@
+ 
+ _create_dirs := $(shell mkdir -p $(OBJDIR) $(LIBDIR))
+ 
+-ifneq ($(findstring ose,$(TARGET)),ose)
++# build dynamic files only where they are useful
++DONT_BUILD_SHARED=
++ifeq ($(findstring ose,$(TARGET)),ose)
++DONT_BUILD_SHARED=yes
++endif
++ifeq ($(findstring rumprun,$(TARGET)),rumprun)
++DONT_BUILD_SHARED=yes
++endif
++
++ifneq ($(DONT_BUILD_SHARED),yes)
+ debug opt valgrind: $(NIF_LIB) $(CALLBACK_LIB)
+ else
+-# Do not build dynamic files on OSE
++# Do not build dynamic files on OSE and rumprun
+ debug opt valgrind:
+ endif
+ 
+@@ -203,7 +212,7 @@
+ 	$(INSTALL_DIR) "$(RELSYSDIR)/priv/obj"
+ 	$(INSTALL_DIR) "$(RELSYSDIR)/priv/lib"
+ 	$(INSTALL_DATA) $(NIF_MAKEFILE) "$(RELSYSDIR)/priv/obj"
+-ifneq ($(findstring ose,$(TARGET)),ose)
++ifneq ($(DONT_BUILD_SHARED),yes)
+ 	$(INSTALL_PROGRAM) $(CRYPTO_OBJS) "$(RELSYSDIR)/priv/obj"
+ 	$(INSTALL_PROGRAM) $(NIF_LIB) "$(RELSYSDIR)/priv/lib"
+ ifeq ($(DYNAMIC_CRYPTO_LIB),yes)


### PR DESCRIPTION
The following changeset makes Erlang available on rumprun.
The documentation in erlang/README.md is faily exhaustive to cover various
aspects including shortcomings in the current state of this change.
I do intend to solve them one at a time, though in no particular order.
I did not test it on xen, because I dont have one at present and things
_should_ just work.

Signed-off-by: Neeraj Sharma neeraj.sharma@alumni.iitg.ernet.in
