### PR TITLE
Add Makefile for Rust, cargo and cargo-rumpbake

### DIFF
--- a/rust/Makefile
+++ b/rust/Makefile
@@ -1,0 +1,102 @@
+include ../Makefile.inc
+RUST_GIT=https://github.com/rust-lang/rust.git
+RUST_VER=c9c79084
+
+CARGO_GIT=https://github.com/rust-lang/cargo.git
+CARGO_VER=0.5.0
+
+CARGO_RUMPBAKE_GIT=https://github.com/gandro/cargo-rumpbake.git
+CARGO_RUMPBAKE_VER=0.5.0
+
+ifneq (x86_64-rumprun-netbsd,$(RUMPRUN_TOOLCHAIN_TUPLE))
+$(error Rust currently only supports x86_64-rumprun-netbsd)
+endif
+
+RUST_DESTDIR ?= $(abspath build/destdir)
+CARGO_HOME := $(RUST_DESTDIR)/cargo
+
+all: rust cargo cargo-rumpbake
+
+######################################################################
+# rust - The Rust compiler and standard library
+######################################################################
+
+.PHONY: rust
+rust: $(RUST_DESTDIR)/bin/rustc rustenv.sh
+
+$(RUST_DESTDIR)/bin/rustc: build/rust/config.stamp
+	mkdir -p $(RUST_DESTDIR)
+	(cd build/rust; $(MAKE) && $(MAKE) install)
+
+RUST_CONF_OPTS += \
+	--target=$(RUMPRUN_TOOLCHAIN_TUPLE) \
+	--prefix=$(RUST_DESTDIR) \
+	--enable-debug
+
+build/rust/config.stamp: build/rust/configure
+	(cd build/rust; ./configure $(RUST_CONF_OPTS))
+
+build/rust/configure:
+	mkdir -p build
+	(cd build && \
+		git clone $(RUST_GIT) && \
+		cd rust && git checkout $(RUST_VER))
+
+rustenv.sh: $(RUST_DESTDIR)/bin/rustc
+	echo 'export PATH=$(RUST_DESTDIR)/bin:$${PATH}' > rustenv.sh
+	echo 'export LD_LIBRARY_PATH="$(RUST_DESTDIR)/lib:$${LD_LIBRARY_PATH}"' >> rustenv.sh
+	echo 'export DYLD_LIBRARY_PATH="$(RUST_DESTDIR)/lib:$${DYLD_LIBRARY_PATH}"' >> rustenv.sh
+
+######################################################################
+# cargo - The Rust package manager and build tool
+######################################################################
+
+.PHONY: cargo
+cargo: $(RUST_DESTDIR)/bin/cargo
+
+$(RUST_DESTDIR)/bin/cargo: build/cargo/config.stamp
+	mkdir -p $(RUST_DESTDIR)
+	(cd build/cargo; \
+		export CARGO_HOME=$(CARGO_HOME) && \
+		$(MAKE) && \
+		$(MAKE) install && \
+		echo 'export CARGO_HOME=$(CARGO_HOME)' >> rustenv.sh)
+
+CARGO_CONF_OPTS += \
+	--local-rust-root=$(RUST_DESTDIR) \
+	--prefix=$(RUST_DESTDIR)
+
+build/cargo/config.stamp: build/cargo/configure
+	(cd build/cargo; \
+		git submodule update --init && \
+		./configure $(CARGO_CONF_OPTS))
+
+build/cargo/configure: $(RUST_DESTDIR)/bin/rustc
+	(cd build && git clone --branch $(CARGO_VER) $(CARGO_GIT))
+
+######################################################################
+# cargo-rumpbake - Cargo subcommand for invoking rumpbake
+######################################################################
+
+.PHONY: cargo-rumpbake
+cargo-rumpbake: $(RUST_DESTDIR)/bin/cargo-rumpbake
+
+$(RUST_DESTDIR)/bin/cargo-rumpbake: build/cargo-rumpbake/Cargo.toml
+	(cd build/cargo-rumpbake && \
+		sh -c '. ../../rustenv.sh ; cargo build --release' && \
+		cp target/release/cargo-rumpbake "$@")
+
+build/cargo-rumpbake/Cargo.toml: $(RUST_DESTDIR)/bin/cargo
+	mkdir -p build
+	(cd build && \
+		git clone --branch $(CARGO_RUMPBAKE_VER) $(CARGO_RUMPBAKE_GIT))
+
+.PHONY: clean
+clean:
+	-$(MAKE) -C build/rust clean
+	-$(MAKE) -C build/cargo clean
+	rm -f rustenv.sh
+
+.PHONY: cleandir
+cleandir: clean
+	rm -rf build

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,83 @@
+Overview
+========
+
+This document explains how to build a Rust cross-compiler and the cargo package
+manager for rumprun. The Rust compiler version is a 1.5.0-dev snapshot
+(the first version that supports Rumprun), cargo and cargo-rumpbake are
+version 0.5.0.
+
+This package also fetches and builds a copy of
+[cargo-rumpbake](https://github.com/gandro/cargo-rumpbake), a small wrapper
+around `cargo build` and `rumpbake` which simplifies building and baking when
+using `cargo` as a build tool.
+
+Instructions
+============
+
+Running `make` will build a Rust cross-compiler for Rumprun, including the
+standard library. The cargo package manager and the cargo-rumpbake subcommand
+are also included by default. To build Rust without cargo, run `make rust`.
+
+Make sure the `app-tools` folder of your Rumprun build is in `$PATH`.
+
+    cd rumprun-packages/rust
+    make -j4
+
+Rust has the following host dependencies:
+
+   * `g++` 4.7 or `clang++` 3.x
+   * `python` 2.6 or later (but not 3.x)
+   * GNU `make` 3.81 or later
+   * `curl`
+   * `git`
+
+You will also need a decent Internet connection, at least 1.5 GB of RAM and
+around five GB of disk space. Be aware, compiling Rust can easily take two
+hours or more.
+
+The toolchain will be installed in `build/destdir`. In order to use it, you
+will need to set `LD_LIBRARY_PATH`. The following command sets the appropriate
+environment variables to invoke `rustc` and `cargo` directly:
+
+    . ./rustenv.sh
+
+> **Tip**: If you are using [multirust](https://github.com/brson/multirust), 
+> you can configure a custom toolchain instead of using rustenv.sh.
+> `multirust update rumprun --link-local $(readlink -f build/destdir/)`
+
+Examples
+========
+
+To cross-compile for Rumprun, always make sure you have `app-tools` in your
+path, because `rustc` will invoke `x86_64-rumprun-netbsd-{gcc,ar}`.
+
+When compiling manually with `rustc` or `cargo build`, make sure to compile
+for the Rumprun target with `--target=x86_64-rumprun-netbsd`. For example:
+
+    cd examples/hello
+    rustc --target=x86_64-rumprun-netbsd hello.rs
+    rumpbake hw_virtio hello.img hello
+    rumprun qemu -i hello.img
+
+### cargo rumpbake
+
+When building with cargo, you can use `cargo rumpbake`, a tool which invokes
+rumpbake automatically. To build the example TCP/IP server, proceed as follows:
+
+    cd examples/hello-tcp
+    cargo rumpbake hw_virtio
+
+This will build and bake a `hello-tcp.img` unikernel image. To run it, make sure
+you configure the network correctly. For example on Linux:
+
+    sudo ip tuntap add tap0 mode tap
+    sudo ip addr add 10.0.23.2/24 dev tap0
+    sudo ip link set dev tap0 up
+    rumprun qemu \
+       -I if,vioif,'-net tap,script=no,ifname=tap0' \
+       -W if,inet,static,10.0.23.1/24 \
+       -i hello-tcp.img
+
+You can connect to the server with telnet:
+
+    telnet 10.0.23.1 9023

--- a/rust/examples/hello-tcp/Cargo.toml
+++ b/rust/examples/hello-tcp/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "hello-tcp"
+version = "0.1.0"
+authors = ["Sebastian Wicki <gandro@gmx.net>"]

--- a/rust/examples/hello-tcp/src/main.rs
+++ b/rust/examples/hello-tcp/src/main.rs
@@ -1,0 +1,25 @@
+use std::io::{BufReader, BufRead, Write, Result};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+
+fn handle(stream: Result<TcpStream>) -> Result<()> {
+    let mut stream = try!(stream);
+    try!(stream.write_all(b"Hello, this is rumprun. Who are you?\r\n"));
+    
+    let mut name = String::new();
+    try!(BufReader::new(&mut stream).read_line(&mut name));
+
+    write!(&mut stream, "Nice to meet you, {}!\r\n", name.trim_right())
+}
+
+fn main() {
+    let listener = TcpListener::bind("0.0.0.0:9023").unwrap();
+    println!("listening on port 9023 started, ready to accept");
+    for stream in listener.incoming() {
+        thread::spawn(|| {
+            if let Err(err) = handle(stream) {
+                println!("an error occured: {}", err);
+            }
+        });
+    }
+}

--- a/rust/examples/hello/Makefile
+++ b/rust/examples/hello/Makefile
@@ -1,0 +1,6 @@
+hello: hello.rs
+	rustc --target=x86_64-rumprun-netbsd $<
+
+.PHONY: clean
+clean:
+	rm -f hello

--- a/rust/examples/hello/hello.rs
+++ b/rust/examples/hello/hello.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, rumprun!");
+}


### PR DESCRIPTION
Support for rumprun has [just landed](https://github.com/rust-lang/rust/pull/28593) in Rust. This adds a Makefile to build a Rust cross-compiler for rumprun, including the cargo package manager and a cargo wrapper that I've made for rumpbake.

In contrast to other packages in this repo, this needs git to fetch the sources, since Rust and cargo depend on being built from git (heavy use of submodules), but I make sure to fetch specific tags/commits, to keep it reproducible. Feedback and testers welcome.
