### PR TITLE
OS X support: command variable for GENISOIMAGE and use in nginx

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -24,6 +24,12 @@ RUMPRUN_CXX=$(RUMPRUN_TOOLCHAIN_TUPLE)-g++
 RUMPRUN_SYSROOT:=$(shell ${RUMPRUN_CC} -print-sysroot)
 RUMPRUN_CMAKE_TOOLCHAIN_FILE:=${RUMPRUN_SYSROOT}/share/${RUMPRUN_TOOLCHAIN_TUPLE}-toolchain.cmake
 
+ifeq ($(shell uname),Darwin)
+RUMPRUN_GENISOIMAGE=hdiutil makehybrid -iso
+else
+RUMPRUN_GENISOIMAGE=genisoimage -l -r
+endif
+
 RUMPRUN_PKGS_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))/pkgs
 
 CPPFLAGS+=-I$(RUMPRUN_PKGS_DIR)/include

--- a/nginx/Makefile
+++ b/nginx/Makefile
@@ -69,10 +69,10 @@ build/configure: | dl/$(TARBALL)
 images: images/stubetc.iso images/data.iso
 
 images/stubetc.iso: ../stubetc/etc/*
-	genisoimage -l -r -o images/stubetc.iso ../stubetc/etc
+	$(RUMPRUN_GENISOIMAGE) -o images/stubetc.iso ../stubetc/etc
 
 images/data.iso: images/data/conf/* images/data/www/*
-	genisoimage -l -r -o images/data.iso images/data
+	$(RUMPRUN_GENISOIMAGE) -o images/data.iso images/data
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
I checked the `hdiutil` invocations and the -hfs / -joliet parameters just generate cross-platform images, which I don't think is necessary here. `genisoimage` only generates ISO9660 by default. So I think the 2 commands are equivalent
