### PR TITLE
Dependency changes

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -4,7 +4,7 @@ UPSTREAM=https://www.python.org/ftp/python/3.4.3/Python-3.4.3.tar.xz
 TARBALL=$(notdir $(UPSTREAM))
 ARCH=$(shell $(RUMPRUN_CC) -dumpmachine)
 
-all: build/python images
+all: images
 
 build/python: build/Makefile
 	$(MAKE) -C build
@@ -42,13 +42,13 @@ build/configure: | dl/$(TARBALL)
 	cp config.site build/
 
 .PHONY: images
-images: images/stubetc.iso images/python.iso
+images: images/stubetc.iso
 
-images/stubetc.iso: ../stubetc/etc/*
+images/stubetc.iso: images/python.iso ../stubetc/etc/*
 	mkdir -p images
 	genisoimage -l -r -o images/stubetc.iso ../stubetc/etc
 
-images/python.iso: build/Makefile
+images/python.iso: build/python
 	mkdir -p images
 	genisoimage -l -r -o images/python.iso build/pythondist/lib/python3.4
 

--- a/python/README.md
+++ b/python/README.md
@@ -38,22 +38,7 @@ make
 Errors
 ======
 
-This build process will return clean ($?==0). However there are some errors that you will notice. One of
-those errors is:
-
-```
-/usr/include/x86_64-linux-gnu/sys/cdefs.h:23:23: fatal error: features.h: No such file or directory
-```
-
-This means you are running on Debian and the build system added /usr/include/<platform tuple> to your
-include path. cdefs.h is searching the netbsd target include dir for features.h, and it simply won't
-find it. If we fix this problem, you will only run into linking errors because extensions just don't
-seem to play well with cross compilation. Not to worry, these extensions will be statically linked
-in your Unikernel anyway. The example will show this.
-
-So this error remains because it is faster to fail at compile time than at linking time.
-
-Another error happens while linking the Unikernel:
+An error happens while linking the Unikernel:
 
 ```
 warning: RC5 is a patented algorithm; link against libcrypto_rc5

--- a/python/patches/0003-patch-setuppy.patch
+++ b/python/patches/0003-patch-setuppy.patch
@@ -1,0 +1,10 @@
+--- a/setup.py.orig	2015-11-05 16:01:33.710271444 -0500
++++ b/setup.py	2015-11-05 16:03:00.054271065 -0500
+@@ -175,6 +175,7 @@
+         self.failed = []
+ 
+     def build_extensions(self):
++        return
+ 
+         # Detect which modules should be compiled
+         missing = self.detect_modules()


### PR DESCRIPTION
Fixed a problem with Makefile dependencies that was causing an error during parallel builds.
Python extensions are forced to link against the host libraries and link incorrectly.
They aren't needed though, so we skip building the extensions.
