### PR TITLE
Fixes #44

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -22,7 +22,7 @@ PYTHON_CONF_OPTS += \
 	--disable-shared \
 	--host=$(RUMPRUN_TOOLCHAIN_TUPLE) \
 	--build $(ARCH) \
-	--disable-ipv6 \
+	--enable-ipv6 \
         --without-ensurepip
 
 build/Makefile: build/stamp_patch

--- a/python/examples/hw.py
+++ b/python/examples/hw.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import socket
 
 # Importing these verifies that our static modules built correctly
 import math
@@ -12,6 +13,10 @@ def hello_world():
     print("Welcome to rumprun/python %d.%d!" % sys.version_info[:2])
     print("{} / {}".format(sys.platform, os.name))
 
+    if socket.has_ipv6:
+        print("IPv6 is enabled")
+
+    print("\n" * 2)
 
 if __name__ == '__main__':
     hello_world()


### PR DESCRIPTION
Explicitly enable IPv6 during Python configuration.
Update the example to display whether the socket supports IPv6.
