### PR TITLE
erlang: import pkgsrc patch for erts' SCTP failure

### DIFF
--- a/erlang/patches/have_SCTP.patch
+++ b/erlang/patches/have_SCTP.patch
@@ -1,0 +1,17 @@
+$NetBSD: patch-erts_emulator_drivers_common_inet__drv.c,v 1.1 2015/11/20 14:30:02 joerg Exp $
+
+--- a/erts/emulator/drivers/common/inet_drv.c.orig	2015-11-17 11:35:14.000000000 +0000
++++ b/erts/emulator/drivers/common/inet_drv.c
+@@ -567,6 +567,12 @@ typedef unsigned long  u_long;
+ #     define sctp_adaptation_layer_event sctp_adaption_layer_event
+ #endif
+ 
++#ifdef __NetBSD__
++#undef SCTP_DELAYED_ACK_TIME
++#undef HAVE_DECL_SCTP_DELAYED_ACK_TIME
++#define HAVE_DECL_SCTP_DELAYED_ACK_TIME 0
++#endif
++
+ #if defined(__GNUC__) && defined(HAVE_SCTP_BINDX)
+ static typeof(sctp_bindx) *p_sctp_bindx = NULL;
+ #else


### PR DESCRIPTION
NetBSD have already unbroken their build with this patch:
http://cvsweb.netbsd.org/bsdweb.cgi/~checkout~/pkgsrc/lang/erlang/patches/patch-erts_emulator_drivers_common_inet__drv.c?rev=1.1&content-type=text/x-cvsweb-markup

we simply follow their footsteps.

This addresses #36 
