### PR TITLE
Node.js: Allow node binaries to co-exist in directory

### DIFF
--- a/nodejs/.gitignore
+++ b/nodejs/.gitignore
@@ -1,3 +1,3 @@
-/build
+/build-*
 /dl
 /patches/**/CVS

--- a/nodejs/.gitignore
+++ b/nodejs/.gitignore
@@ -1,3 +1,4 @@
 /build-*
 /dl
 /patches/**/CVS
+/examples/hello-world.js

--- a/nodejs/.gitignore
+++ b/nodejs/.gitignore
@@ -1,4 +1,3 @@
 /build-*
 /dl
 /patches/**/CVS
-/examples/hello-world.js

--- a/nodejs/Makefile
+++ b/nodejs/Makefile
@@ -1,12 +1,10 @@
 include ../Makefile.inc
+include Makefile.inc
 
-NODE_VERSION=4.2.4
-NODE_BIN=build/out/Release/node
- 
 UPSTREAM=https://github.com/nodejs/node/archive/v$(NODE_VERSION).tar.gz
 TARBALL=$(notdir $(UPSTREAM))
 
-PKGSRC_DIR=pkgsrc/lang/nodejs4/patches
+PKGSRC_DIR=pkgsrc/lang/$(PKGSRC)/patches
 
 RUMPRUN_TOOLCHAIN_ARCH=$(shell echo $(RUMPRUN_TOOLCHAIN_TUPLE) | cut -d - -f 1)
 ifeq ($(RUMPRUN_TOOLCHAIN_ARCH),x86_64)
@@ -28,19 +26,19 @@ export GYP_DEFINES="OS=netbsd"
 
 all: $(NODE_BIN)
 
-$(NODE_BIN): build/node.gyp build/config.mk _third_party_main.js rumpmain.js
-	$(MAKE) -C build
+$(NODE_BIN): $(BUILD_DIR)/node.gyp $(BUILD_DIR)/config.mk _third_party_main.js rumpmain.js
+	$(MAKE) -C $(BUILD_DIR)
 
-build/config.mk: build/stamp_patch
-	(cd build; ./configure --without-snapshot --dest-cpu=$(CPU) --link-module=../_third_party_main.js --link-module=../rumpmain.js)
+$(BUILD_DIR)/config.mk: $(BUILD_DIR)/stamp_patch
+	(cd $(BUILD_DIR); ./configure --without-snapshot --dest-cpu=$(CPU) --link-module=../_third_party_main.js --link-module=../rumpmain.js)
 
-build/stamp_patch: build/configure patches/*.patch | patches/$(PKGSRC_DIR)
-	(cd build && ../../scripts/apply-patches.sh -p 0 ./ ../patches/$(PKGSRC_DIR)/patch-* ../patches/*.patch)
+$(BUILD_DIR)/stamp_patch: $(BUILD_DIR)/configure patches/*.patch | patches/$(PKGSRC_DIR)
+	(cd $(BUILD_DIR) && ../../scripts/apply-patches.sh -p 0 ./ ../patches/$(PKGSRC_DIR)/patch-* ../patches/*.patch)
 	touch $@
 
-build/node.gyp build/configure: | dl/$(TARBALL)
-	mkdir -p build
-	(cd build && tar -x --strip-components 1 -f ../dl/$(TARBALL))
+$(BUILD_DIR)/node.gyp $(BUILD_DIR)/configure: | dl/$(TARBALL)
+	mkdir -p $(BUILD_DIR)
+	(cd $(BUILD_DIR) && tar -x --strip-components 1 -f ../dl/$(TARBALL))
 
 dl/$(TARBALL):
 	mkdir -p dl
@@ -56,9 +54,9 @@ bake_hw_generic:
 
 .PHONY: clean
 clean:
-	if [ -d build ]; then $(MAKE) -C build clean; rm -f $(NODE_BIN).bin; fi
+	if [ -d $(BUILD_DIR) ]; then $(MAKE) -C $(BUILD_DIR) clean; rm -f $(NODE_BIN).bin; fi
 	$(MAKE) -C examples clean
 
 .PHONY: distclean
 distclean:
-	rm -rf build dl
+	rm -rf build-* dl

--- a/nodejs/Makefile
+++ b/nodejs/Makefile
@@ -24,9 +24,14 @@ export RANLIB=$(RUMPRUN_TOOLCHAIN_TUPLE)-ranlib
 export LINK=$(CXX)
 export GYP_DEFINES="OS=netbsd"
 
+NODE_OUT=$(BUILD_DIR)/out/Release/node
+
 all: $(NODE_BIN)
 
-$(NODE_BIN): $(BUILD_DIR)/node.gyp $(BUILD_DIR)/config.mk _third_party_main.js rumpmain.js
+$(NODE_BIN): $(NODE_OUT)
+	cp $^ $@
+
+$(NODE_OUT): $(BUILD_DIR)/node.gyp $(BUILD_DIR)/config.mk _third_party_main.js rumpmain.js
 	$(MAKE) -C $(BUILD_DIR)
 
 $(BUILD_DIR)/config.mk: $(BUILD_DIR)/stamp_patch
@@ -48,13 +53,9 @@ patches/$(PKGSRC_DIR):
 	(cd patches && cvs -q -z2 -d anoncvs@anoncvs.NetBSD.org:/cvsroot checkout -r HEAD -P $(PKGSRC_DIR))
 	perl -pi -e 's/\@PYTHONBIN@/python/g' patches/$(PKGSRC_DIR)/patch-*
 
-.PHONY: bake_hw_generic
-bake_hw_generic:
-	rumprun-bake hw_generic $(NODE_BIN).bin $(NODE_BIN)
-
 .PHONY: clean
 clean:
-	if [ -d $(BUILD_DIR) ]; then $(MAKE) -C $(BUILD_DIR) clean; rm -f $(NODE_BIN).bin; fi
+	if [ -d $(BUILD_DIR) ]; then $(MAKE) -C $(BUILD_DIR) clean; rm -f $(NODE_BIN) $(NODE_BIN).bin; fi
 	$(MAKE) -C examples clean
 
 .PHONY: distclean

--- a/nodejs/Makefile.inc
+++ b/nodejs/Makefile.inc
@@ -1,4 +1,4 @@
 NODE_VERSION=4.2.4
 PKGSRC=nodejs4
 BUILD_DIR=build-$(NODE_VERSION)
-NODE_BIN=$(BUILD_DIR)/out/Release/node
+NODE_BIN=$(BUILD_DIR)/out/Release/node-$(shell basename `readlink $(dir $(realpath $(lastword $(MAKEFILE_LIST))))/rumpmain.js` .js)

--- a/nodejs/Makefile.inc
+++ b/nodejs/Makefile.inc
@@ -1,0 +1,4 @@
+NODE_VERSION=4.2.4
+PKGSRC=nodejs4
+BUILD_DIR=build-$(NODE_VERSION)
+NODE_BIN=$(BUILD_DIR)/out/Release/node

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -30,21 +30,21 @@ There are a couple of changes worth noting:
 Instructions
 ============
 
-Run `make`. This will produce `build/out/Release/node`, which you can then pass
+Run `make`. This will produce `build-4.2.4/out/Release/node`, which you can then pass
 to `rumprun-bake`. If you're using the generic configuration, you can use
-`make bake_hw_generic` to generate `build/out/Release/node.bin`.
+`make bake_hw_generic` to generate `build-4.2.4/out/Release/node.bin`.
 
 You can then run Node using something like this:
 
 ```shell
-rumprun kvm -M 160 -i build/out/Release/node.bin
+rumprun kvm -M 160 -i build-4.2.4/out/Release/node.bin
 ```
 
 Examples
 ========
 
 The files `_third_party_main.js` and `rumpmain.js` in this directory are bundled
- into `build/out/Release/node`. `_third_party_main.js` runs when you launch
+ into `build-4.2.4/out/Release/node`. `_third_party_main.js` runs when you launch
 Node using `rumprun`.
 
 If you give an argument to `node.bin` when running `rumprun`, then
@@ -67,7 +67,7 @@ then to run the "Hello World" example:
 ```shell
 (cd express; npm install --production)
 genisoimage -l -r -o express.iso express/
-rumprun kvm -M 160 -I 'nic,vioif,-net user,hostfwd=tcp::3000-:3000' -W nic,inet,dhcp -i -b express.iso,/express build/out/Release/node.bin /express/examples/hello-world/index.js
+rumprun kvm -M 160 -I 'nic,vioif,-net user,hostfwd=tcp::3000-:3000' -W nic,inet,dhcp -i -b express.iso,/express build-4.2.4/out/Release/node.bin /express/examples/hello-world/index.js
 ```
 
 The second option is to bundle your entire application into a single file,
@@ -82,7 +82,7 @@ npm install webpack json-loader
 ./node_modules/.bin/webpack --target node --module-bind json ./express/examples/hello-world/index.js rumpmain.js
 make
 make bake_hw_generic
-rumprun kvm -M 160 -I 'nic,vioif,-net user,hostfwd=tcp::3000-:3000' -W nic,inet,dhcp -i build/out/Release/node.bin
+rumprun kvm -M 160 -I 'nic,vioif,-net user,hostfwd=tcp::3000-:3000' -W nic,inet,dhcp -i build-4.2.4/out/Release/node.bin
 ```
 
 You can find a sample `Makefile` for both options in the `examples` directory.
@@ -90,8 +90,8 @@ In the `examples` directory, type `make run_express_hello_world` to run the
 filesystem (`.iso`) option. Type `make bundle_express_hello_world;
 make -C .. bake_hw_generic; make run_kvm` to run the bundled version.
 
-Please note it's best to use a version of `npm` in the 4.1.x series when
-installing your application's dependencies on your build system.
+Please note it's best to use Node 4.2.4 (and associated `npm` version) on your
+build system when installing you application's dependencies.
 
 Native Addons
 =============
@@ -115,18 +115,18 @@ Error: Service unavailable
 The solution is to compile the Addon into the Node binary itself. Whilst this
 isn't something you usually do, it's quite simple:
 
-1. Add the full pathnames of the Addon's source and header files to `build/node.gyp`.
+1. Add the full pathnames of the Addon's source and header files to `build-4.2.4/node.gyp`.
   - Either do this by hand:
     1. Add the source files to `targets`&rarr;`sources` 
     2. Add the header files to `targets`&rarr;`include_dirs`
   - Or use [`nad`](https://github.com/thlorenz/nad):
     1. `npm install -g nad`
     2. `cd /path/to/addon`
-    2. `nad configure --nodedir /path/to/rumprun-packages/nodejs/build`
+    2. `nad configure --nodedir /path/to/rumprun-packages/nodejs/build-4.2.4`
     3. `nad inject`
 2. Run `NODE_PATH=/path/to/addon/node_modules make`
 
-The Addon is now compiled into the Node binary (`build/out/Release/node`),
+The Addon is now compiled into the Node binary (`build-4.2.4/out/Release/node`),
 which you can bake and run as normal.
 
 I've added an example of using an Addon in `examples/ursa/test.js`:
@@ -134,21 +134,32 @@ I've added an example of using an Addon in `examples/ursa/test.js`:
 1. In the `examples` directory, run `make ursa.iso`. This installs the
    [`ursa`](https://github.com/quartzjer/ursa) module and adds it to a `.iso`
    file.
-2. Next, you have to add `ursa`'s Addon to `build/node.gyp`.
-  - Either modify `build/node.gyp` by hand:
+2. Next, you have to add `ursa`'s Addon to `build-4.2.4/node.gyp`.
+  - Either modify `build-4.2.4/node.gyp` by hand:
     1. In `sources` (under `targets`), add `'../examples/ursa/node_modules/ursa/src/ursaNative.cc'`
     2. In `include_dirs` (under `targets`), add `'../examples/ursa/node_modules/ursa/node_modules/nan'`
     3. Run `make`
   - Or run `make inject_ursa` in the `examples` directory. This uses `nad` to
-    modify `build/node.gyp` and then runs `make` with `NODE_PATH` set.
+    modify `build-4.2.4/node.gyp` and then runs `make` with `NODE_PATH` set.
 3. Bake the Node binary (`make bake_hw_generic`)
 4. In the `examples` directory, run `make run_ursa`. You should see a
    PEM-formatted public key displayed.
 
+Node 5
+======
+
+Node 5.3.0 is known to build successfully. Change the first two lines of
+`Makefile.inc` to:
+
+```make
+NODE_VERSION=5.3.0
+PKGSRC=nodejs
+```
+
 Known Issues
 ============
 
-- If you use `nad` to inject more than one Addon into `build/node.gyp`, you
-  might run into problems. You'll end up with conflicting definitions for
+- If you use `nad` to inject more than one Addon into `build-4.2.4/node.gyp`,
+  you might run into problems. You'll end up with conflicting definitions for
   `module_root_dir`, so if both the Addons rely on its value then one will
   fail to compile.

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -171,12 +171,10 @@ I've added an example of using an Addon in `examples/ursa/test.js`:
 Node 5
 ======
 
-Node 5.3.0 is known to build successfully. Change the first two lines of
-`Makefile.inc` to:
+Node 5.3.0 is known to build successfully:
 
-```make
-NODE_VERSION=5.3.0
-PKGSRC=nodejs
+```shell
+make NODE_VERSION=5.3.0 PKGSRC=nodejs
 ```
 
 Known Issues

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -30,28 +30,36 @@ There are a couple of changes worth noting:
 Instructions
 ============
 
-Run `make`. This will produce `build-4.2.4/out/Release/node`, which you can then pass
-to `rumprun-bake`. If you're using the generic configuration, you can use
-`make bake_hw_generic` to generate `build-4.2.4/out/Release/node.bin`.
+Run `make`. This will produce `build-4.2.4/out/Release/node-default`, which you
+can then pass to `rumprun-bake` &mdash; for example:
+
+```shell
+rumprun-bake hw_generic build-4.2.4/out/Release/node-default.bin build-4.2.4/out/Release/node-default
+```
 
 You can then run Node using something like this:
 
 ```shell
-rumprun kvm -M 160 -i build-4.2.4/out/Release/node.bin
+rumprun kvm -M 160 -i build-4.2.4/out/Release/node-default.bin
 ```
 
 Examples
 ========
 
 The files `_third_party_main.js` and `rumpmain.js` in this directory are bundled
- into `build-4.2.4/out/Release/node`. `_third_party_main.js` runs when you launch
-Node using `rumprun`.
+into `build-4.2.4/out/Release/node-default`. `_third_party_main.js` runs when
+you launch Node using `rumprun`.
 
-If you give an argument to `node.bin` when running `rumprun`, then
+If you give an argument to `node-default.bin` when running `rumprun`, then
 `_third_party_main.js` treats it as a pathname and runs the script in that file.
 If you don't give an argument, it runs `rumpmain.js`, which just displays a
-message and exits. You can of course change `rumpmain.js` to do anything you
-like.
+message and exits.
+
+`rumpmain.js` ships as a symbolic link to `default.js`. You can of course link
+`rumpmain.js` to a different file. Please note this will change the name of the
+output binary too, based on the name of the file you link to. For example,
+if you link `rumpmain.js` to `foo.js` then `make` will produce
+`build-4.2.4/out/Release/node-foo`.
 
 Most applications require code in separate modules, and you have two
 options for running these.
@@ -59,19 +67,19 @@ options for running these.
 The first option is to put your application's files into a filesystem (e.g.
 using `genisoimage`) and attach it to `rumprun` using the `-b` option. You can
 then give the path to the main file of your application as an argument to
-`rumprun`, after `node.bin`.
+`rumprun`, after `node-default.bin`.
 
-For instance, assuming Express is checked out into the 'express' directory,
+For instance, assuming Express is checked out into the `express` directory,
 then to run the "Hello World" example:
 
 ```shell
 (cd express; npm install --production)
 genisoimage -l -r -o express.iso express/
-rumprun kvm -M 160 -I 'nic,vioif,-net user,hostfwd=tcp::3000-:3000' -W nic,inet,dhcp -i -b express.iso,/express build-4.2.4/out/Release/node.bin /express/examples/hello-world/index.js
+rumprun kvm -M 160 -I 'nic,vioif,-net user,hostfwd=tcp::3000-:3000' -W nic,inet,dhcp -i -b express.iso,/express build-4.2.4/out/Release/node-default.bin /express/examples/hello-world/index.js
 ```
 
 The second option is to bundle your entire application into a single file,
-and overwrite `rumpmain.js`. You can do this using
+and link `rumpmain.js` to it. You can do this using
 [webpack](http://webpack.github.io/).
 
 For instance, to run the same Express "Hello World" example:
@@ -79,16 +87,29 @@ For instance, to run the same Express "Hello World" example:
 ```
 npm install webpack json-loader
 (cd express; npm install --production)
-./node_modules/.bin/webpack --target node --module-bind json ./express/examples/hello-world/index.js rumpmain.js
+./node_modules/.bin/webpack --target node --module-bind json ./express/examples/hello-world/index.js hello-world.js
+ln -sf hello-world.js rumpmain.js
 make
-make bake_hw_generic
-rumprun kvm -M 160 -I 'nic,vioif,-net user,hostfwd=tcp::3000-:3000' -W nic,inet,dhcp -i build-4.2.4/out/Release/node.bin
+rumprun-bake hw_generic build-4.2.4/out/Release/node-hello-world.bin build-4.2.4/out/Release/node-hello-world
+rumprun kvm -M 160 -I 'nic,vioif,-net user,hostfwd=tcp::3000-:3000' -W nic,inet,dhcp -i build-4.2.4/out/Release/node-hello-world.bin
 ```
 
 You can find a sample `Makefile` for both options in the `examples` directory.
-In the `examples` directory, type `make run_express_hello_world` to run the
-filesystem (`.iso`) option. Type `make bundle_express_hello_world;
-make -C .. bake_hw_generic; make run_kvm` to run the bundled version.
+
+In the `examples` directory, type the following to run the filesystem (`.iso`)
+option:
+
+```shell
+make run_express_hello_world
+```
+
+Type the following to run the bundled version:
+
+```shell
+make bundle_express_hello_world
+rumprun-bake hw_generic ../build-4.2.4/out/Release/node-hello-world.bin ../build-4.2.4/out/Release/node-hello-world
+make run_kvm
+```
 
 Please note it's best to use Node 4.2.4 (and associated `npm` version) on your
 build system when installing you application's dependencies.
@@ -113,21 +134,23 @@ Error: Service unavailable
 ```
 
 The solution is to compile the Addon into the Node binary itself. Whilst this
-isn't something you usually do, it's quite simple:
+isn't something you usually do, it's quite simple. You need to add the full
+pathnames of the Addon's source and header files to `build-4.2.4/node.gyp`.
 
-1. Add the full pathnames of the Addon's source and header files to `build-4.2.4/node.gyp`.
-  - Either do this by hand:
-    1. Add the source files to `targets`&rarr;`sources` 
-    2. Add the header files to `targets`&rarr;`include_dirs`
-  - Or use [`nad`](https://github.com/thlorenz/nad):
-    1. `npm install -g nad`
-    2. `cd /path/to/addon`
-    2. `nad configure --nodedir /path/to/rumprun-packages/nodejs/build-4.2.4`
-    3. `nad inject`
-2. Run `NODE_PATH=/path/to/addon/node_modules make`
+- Either do this by hand:
+  1. Add the source files to `targets`&rarr;`sources` 
+  2. Add the header files to `targets`&rarr;`include_dirs`
+  3. Run `make`
+- Or use [`nad`](https://github.com/thlorenz/nad):
+  1. `npm install -g nad`
+  2. `cd /path/to/addon`
+  2. `nad configure --nodedir /path/to/rumprun-packages/nodejs/build-4.2.4`
+  3. `nad inject`
+  4. Run `NODE_PATH=/path/to/addon/node_modules make`
 
-The Addon is now compiled into the Node binary (`build-4.2.4/out/Release/node`),
-which you can bake and run as normal.
+The Addon is now compiled into the Node binary, which you can bake and run as
+normal. Remember the Node binary will be `build-4.2.4/out/Release/node-default`
+unless you've linked `rumpmain.js` to something other than `default.js`.
 
 I've added an example of using an Addon in `examples/ursa/test.js`:
 
@@ -141,7 +164,7 @@ I've added an example of using an Addon in `examples/ursa/test.js`:
     3. Run `make`
   - Or run `make inject_ursa` in the `examples` directory. This uses `nad` to
     modify `build-4.2.4/node.gyp` and then runs `make` with `NODE_PATH` set.
-3. Bake the Node binary (`make bake_hw_generic`)
+3. Bake the Node binary (e.g. `rumprun-bake hw_generic build-4.2.4/out/Release/node-default.bin build-4.2.4/out/Release/node-default`)
 4. In the `examples` directory, run `make run_ursa`. You should see a
    PEM-formatted public key displayed.
 

--- a/nodejs/default.js
+++ b/nodejs/default.js
@@ -1,0 +1,1 @@
+console.log("Hello, Rump!!");

--- a/nodejs/examples/.gitignore
+++ b/nodejs/examples/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 /express-*
 /*.iso
+/hello-world.js

--- a/nodejs/examples/Makefile
+++ b/nodejs/examples/Makefile
@@ -44,4 +44,4 @@ ursa/node_modules/ursa:
 
 .PHONY: clean
 clean:
-	rm -rf *.iso node_modules ursa/node_modules express-*
+	rm -rf *.iso node_modules ursa/node_modules express-* hello-world.js

--- a/nodejs/examples/Makefile
+++ b/nodejs/examples/Makefile
@@ -7,16 +7,17 @@ express-$(EXPRESS_VERSION).iso: | express-$(EXPRESS_VERSION)
 
 .PHONY: run_express_hello_world
 run_express_hello_world: express-$(EXPRESS_VERSION).iso
-	rumprun kvm -M 160 -I 'nic,vioif,-net user,hostfwd=tcp::3000-:3000' -W nic,inet,dhcp -i -b express-$(EXPRESS_VERSION).iso,/express ../$(NODE_BIN) /express/examples/hello-world/index.js
+	rumprun kvm -M 160 -I 'nic,vioif,-net user,hostfwd=tcp::3000-:3000' -W nic,inet,dhcp -i -b express-$(EXPRESS_VERSION).iso,/express ../$(NODE_BIN).bin /express/examples/hello-world/index.js
 
 .PHONY: bundle_express_hello_world
 bundle_express_hello_world: | node_modules express-$(EXPRESS_VERSION)
-	./node_modules/.bin/webpack --target node --module-bind json ./express-$(EXPRESS_VERSION)/examples/hello-world/index.js ../rumpmain.js
+	./node_modules/.bin/webpack --target node --module-bind json ./express-$(EXPRESS_VERSION)/examples/hello-world/index.js hello-world.js
+	ln -sf examples/hello-world.js ../rumpmain.js
 	make -C ..
 
 .PHONY: run_kvm
 run_kvm:
-	rumprun kvm -M 160 -I 'nic,vioif,-net user,hostfwd=tcp::3000-:3000' -W nic,inet,dhcp -i ../$(NODE_BIN)
+	rumprun kvm -M 160 -I 'nic,vioif,-net user,hostfwd=tcp::3000-:3000' -W nic,inet,dhcp -i ../$(NODE_BIN).bin
 
 ursa.iso: ursa/test.js | node_modules ursa/node_modules/ursa
 	genisoimage -l -r -o $@ ursa
@@ -29,7 +30,7 @@ inject_ursa: | node_modules ursa/node_modules/ursa
 
 .PHONY: run_ursa
 run_ursa: ursa.iso
-	rumprun kvm -M 160 -i -b ursa.iso,/ursa ../$(NODE_BIN) /ursa/test.js
+	rumprun kvm -M 160 -i -b ursa.iso,/ursa ../$(NODE_BIN).bin /ursa/test.js
 
 node_modules:
 	npm install webpack json-loader nad

--- a/nodejs/examples/Makefile
+++ b/nodejs/examples/Makefile
@@ -1,3 +1,5 @@
+include ../Makefile.inc
+
 EXPRESS_VERSION=4.13.3
 
 express-$(EXPRESS_VERSION).iso: | express-$(EXPRESS_VERSION)
@@ -5,7 +7,7 @@ express-$(EXPRESS_VERSION).iso: | express-$(EXPRESS_VERSION)
 
 .PHONY: run_express_hello_world
 run_express_hello_world: express-$(EXPRESS_VERSION).iso
-	rumprun kvm -M 160 -I 'nic,vioif,-net user,hostfwd=tcp::3000-:3000' -W nic,inet,dhcp -i -b express-$(EXPRESS_VERSION).iso,/express ../build/out/Release/node.bin /express/examples/hello-world/index.js
+	rumprun kvm -M 160 -I 'nic,vioif,-net user,hostfwd=tcp::3000-:3000' -W nic,inet,dhcp -i -b express-$(EXPRESS_VERSION).iso,/express ../$(NODE_BIN) /express/examples/hello-world/index.js
 
 .PHONY: bundle_express_hello_world
 bundle_express_hello_world: | node_modules express-$(EXPRESS_VERSION)
@@ -14,7 +16,7 @@ bundle_express_hello_world: | node_modules express-$(EXPRESS_VERSION)
 
 .PHONY: run_kvm
 run_kvm:
-	rumprun kvm -M 160 -I 'nic,vioif,-net user,hostfwd=tcp::3000-:3000' -W nic,inet,dhcp -i ../build/out/Release/node.bin
+	rumprun kvm -M 160 -I 'nic,vioif,-net user,hostfwd=tcp::3000-:3000' -W nic,inet,dhcp -i ../$(NODE_BIN)
 
 ursa.iso: ursa/test.js | node_modules ursa/node_modules/ursa
 	genisoimage -l -r -o $@ ursa
@@ -22,12 +24,12 @@ ursa.iso: ursa/test.js | node_modules ursa/node_modules/ursa
 NAD=../../../node_modules/.bin/nad
 .PHONY: inject_ursa
 inject_ursa: | node_modules ursa/node_modules/ursa
-	(cd ursa/node_modules/ursa; $(NAD) configure --nodedir ../../../../build; $(NAD) inject)
+	(cd ursa/node_modules/ursa; $(NAD) configure --nodedir ../../../../$(BUILD_DIR); $(NAD) inject)
 	NODE_PATH=../examples/ursa/node_modules/ursa/node_modules make -C ..
 
 .PHONY: run_ursa
 run_ursa: ursa.iso
-	rumprun kvm -M 160 -i -b ursa.iso,/ursa ../build/out/Release/node.bin /ursa/test.js
+	rumprun kvm -M 160 -i -b ursa.iso,/ursa ../$(NODE_BIN) /ursa/test.js
 
 node_modules:
 	npm install webpack json-loader nad

--- a/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-common.gypi
+++ b/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-common.gypi
@@ -1,0 +1,15 @@
+$NetBSD: patch-common.gypi,v 1.4 2015/09/17 10:42:34 fhajny Exp $
+
+Add support for NetBSD.
+
+--- common.gypi.orig	2015-09-08 15:30:34.000000000 +0000
++++ common.gypi
+@@ -221,7 +221,7 @@
+         'cflags': [ '-pthread', ],
+         'ldflags': [ '-pthread' ],
+       }],
+-      [ 'OS in "linux freebsd openbsd solaris android aix"', {
++      [ 'OS in "linux freebsd openbsd solaris android aix netbsd"', {
+         'cflags': [ '-Wall', '-Wextra', '-Wno-unused-parameter', ],
+         'cflags_cc': [ '-fno-rtti', '-fno-exceptions', '-std=gnu++0x' ],
+         'ldflags': [ '-rdynamic' ],

--- a/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_cares_cares.gyp
+++ b/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_cares_cares.gyp
@@ -1,0 +1,16 @@
+$NetBSD: patch-deps_cares_cares.gyp,v 1.1 2013/05/22 15:17:07 mspo Exp $
+
+Add support for NetBSD.
+--- deps/cares/cares.gyp.orig	2013-03-14 10:55:24.000000000 +0900
++++ deps/cares/cares.gyp	2013-03-14 10:55:47.000000000 +0900
+@@ -140,6 +140,10 @@
+           'include_dirs': [ 'config/freebsd' ],
+           'sources': [ 'config/freebsd/ares_config.h' ]
+         }],
++        [ 'OS=="netbsd"', {
++          'include_dirs': [ 'config/netbsd' ],
++          'sources': [ 'config/netbsd/ares_config.h' ]
++        }],
+         [ 'OS=="openbsd"', {
+           'include_dirs': [ 'config/openbsd' ],
+           'sources': [ 'config/openbsd/ares_config.h' ]

--- a/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_npm_node__modules_node-gyp_gyp_pylib_gyp_generator_make.py
+++ b/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_npm_node__modules_node-gyp_gyp_pylib_gyp_generator_make.py
@@ -1,0 +1,15 @@
+$NetBSD: patch-deps_npm_node__modules_node-gyp_gyp_pylib_gyp_generator_make.py,v 1.1 2013/06/26 11:53:02 jperkin Exp $
+
+Ensure we use the system libtool on OSX.
+
+--- deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/make.py.orig	2013-06-13 17:35:30.000000000 +0000
++++ deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/make.py
+@@ -161,7 +161,7 @@ cmd_solink_module = $(LINK.$(TOOLSET)) -
+ 
+ LINK_COMMANDS_MAC = """\
+ quiet_cmd_alink = LIBTOOL-STATIC $@
+-cmd_alink = rm -f $@ && ./gyp-mac-tool filter-libtool libtool $(GYP_LIBTOOLFLAGS) -static -o $@ $(filter %.o,$^)
++cmd_alink = rm -f $@ && ./gyp-mac-tool filter-libtool /usr/bin/libtool $(GYP_LIBTOOLFLAGS) -static -o $@ $(filter %.o,$^)
+ 
+ quiet_cmd_link = LINK($(TOOLSET)) $@
+ cmd_link = $(LINK.$(TOOLSET)) $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -o "$@" $(LD_INPUTS) $(LIBS)

--- a/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_uv_common.gypi
+++ b/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_uv_common.gypi
@@ -1,0 +1,15 @@
+$NetBSD: patch-deps_uv_common.gypi,v 1.3 2015/09/17 10:42:34 fhajny Exp $
+
+Add support for NetBSD.
+
+--- deps/uv/common.gypi.orig	2015-03-31 22:13:01.000000000 +0000
++++ deps/uv/common.gypi
+@@ -128,7 +128,7 @@
+           }]
+         ]
+       }],
+-      ['OS in "freebsd dragonflybsd linux openbsd solaris android"', {
++      ['OS in "freebsd dragonflybsd linux openbsd solaris android netbsd"', {
+         'cflags': [ '-Wall' ],
+         'cflags_cc': [ '-fno-rtti', '-fno-exceptions' ],
+         'target_conditions': [

--- a/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_v8_src_arm_cpu-arm.cc
+++ b/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_v8_src_arm_cpu-arm.cc
@@ -1,0 +1,25 @@
+$NetBSD: patch-deps_v8_src_arm_cpu-arm.cc,v 1.1 2015/10/21 23:46:28 jmcneill Exp $
+
+--- deps/v8/src/arm/cpu-arm.cc.orig	2015-10-13 17:20:07.000000000 +0000
++++ deps/v8/src/arm/cpu-arm.cc
+@@ -7,6 +7,9 @@
+ #ifdef __QNXNTO__
+ #include <sys/mman.h>  // for cache flushing.
+ #undef MAP_TYPE
++#elif defined(__NetBSD__)
++#include <sys/types.h>
++#include <machine/sysarch.h> // for cache flushing.
+ #else
+ #include <sys/syscall.h>  // for cache flushing.
+ #endif
+@@ -40,6 +43,10 @@ void CpuFeatures::FlushICache(void* star
+ #elif V8_OS_QNX
+   msync(start, size, MS_SYNC | MS_INVALIDATE_ICACHE);
+ 
++#elif defined(__NetBSD__)
++  struct arm_sync_icache_args args = { .addr = (uintptr_t)start, .len = size };
++  sysarch(ARM_SYNC_ICACHE, (void *)&args);
++
+ #else
+   register uint32_t beg asm("r0") = reinterpret_cast<uint32_t>(start);
+   register uint32_t end asm("r1") = beg + size;

--- a/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_v8_src_base_atomicops.h
+++ b/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_v8_src_base_atomicops.h
@@ -1,0 +1,18 @@
+$NetBSD: patch-deps_v8_src_base_atomicops.h,v 1.1 2015/10/21 23:46:28 jmcneill Exp $
+
+--- deps/v8/src/base/atomicops.h.orig	2015-10-13 17:20:07.000000000 +0000
++++ deps/v8/src/base/atomicops.h
+@@ -54,9 +54,13 @@ typedef intptr_t Atomic64;
+ #endif  // defined(V8_HOST_ARCH_64_BIT)
+ #endif  // defined(__native_client__)
+ 
++#if defined(__NetBSD__) && defined(__arm__)
++typedef int32_t AtomicWord;
++#else
+ // Use AtomicWord for a machine-sized pointer.  It will use the Atomic32 or
+ // Atomic64 routines below, depending on your architecture.
+ typedef intptr_t AtomicWord;
++#endif
+ 
+ // Atomically execute:
+ //      result = *ptr;

--- a/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_v8_src_base_atomicops__internals__arm__gcc.h
+++ b/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_v8_src_base_atomicops__internals__arm__gcc.h
@@ -1,0 +1,25 @@
+$NetBSD: patch-deps_v8_src_base_atomicops__internals__arm__gcc.h,v 1.1 2015/10/21 23:46:28 jmcneill Exp $
+
+--- deps/v8/src/base/atomicops_internals_arm_gcc.h.orig	2015-10-13 17:20:07.000000000 +0000
++++ deps/v8/src/base/atomicops_internals_arm_gcc.h
+@@ -13,6 +13,11 @@
+ #include <sys/cpuinline.h>
+ #endif
+ 
++#if defined(__NetBSD__)
++#include <sys/types.h>
++#include <machine/sysarch.h>
++#endif
++
+ namespace v8 {
+ namespace base {
+ 
+@@ -50,6 +55,8 @@ inline void MemoryBarrier() {
+   ((KernelMemoryBarrierFunc)0xffff0fa0)();
+ #elif defined(__QNXNTO__)
+   __cpu_membarrier();
++#elif defined(__NetBSD__)
++  sysarch(ARM_DRAIN_WRITEBUF, (void *)0);
+ #else
+ #error MemoryBarrier() is not implemented on this platform.
+ #endif

--- a/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_v8_src_base_platform_platform-freebsd.cc
+++ b/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_v8_src_base_platform_platform-freebsd.cc
@@ -1,0 +1,32 @@
+$NetBSD: patch-deps_v8_src_base_platform_platform-freebsd.cc,v 1.1 2015/08/26 06:57:01 rumko Exp $
+
+Overlapping variables, taken from https://github.com/joyent/node/issues/9175
+
+--- deps/v8/src/base/platform/platform-freebsd.cc.orig	2015-05-23 03:06:54.000000000 +0000
++++ deps/v8/src/base/platform/platform-freebsd.cc
+@@ -122,10 +122,10 @@ static unsigned StringToLong(char* buffe
+ 
+ 
+ std::vector<OS::SharedLibraryAddress> OS::GetSharedLibraryAddresses() {
+-  std::vector<SharedLibraryAddress> result;
++  std::vector<SharedLibraryAddress> address_result;
+   static const int MAP_LENGTH = 1024;
+   int fd = open("/proc/self/maps", O_RDONLY);
+-  if (fd < 0) return result;
++  if (fd < 0) return address_result;
+   while (true) {
+     char addr_buffer[11];
+     addr_buffer[0] = '0';
+@@ -156,10 +156,10 @@ std::vector<OS::SharedLibraryAddress> OS
+     // There may be no filename in this line.  Skip to next.
+     if (start_of_path == NULL) continue;
+     buffer[bytes_read] = 0;
+-    result.push_back(SharedLibraryAddress(start_of_path, start, end));
++    address_result.push_back(SharedLibraryAddress(start_of_path, start, end));
+   }
+   close(fd);
+-  return result;
++  return address_result;
+ }
+ 
+ 

--- a/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_v8_src_base_platform_platform-openbsd.cc
+++ b/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_v8_src_base_platform_platform-openbsd.cc
@@ -1,0 +1,53 @@
+$NetBSD: patch-deps_v8_src_base_platform_platform-openbsd.cc,v 1.1 2015/10/21 23:46:28 jmcneill Exp $
+
+--- deps/v8/src/base/platform/platform-openbsd.cc.orig	2015-10-13 17:20:07.000000000 +0000
++++ deps/v8/src/base/platform/platform-openbsd.cc
+@@ -34,6 +34,48 @@
+ namespace v8 {
+ namespace base {
+ 
++#ifdef __arm__
++
++bool OS::ArmUsingHardFloat() {
++  // GCC versions 4.6 and above define __ARM_PCS or __ARM_PCS_VFP to specify
++  // the Floating Point ABI used (PCS stands for Procedure Call Standard).
++  // We use these as well as a couple of other defines to statically determine
++  // what FP ABI used.
++  // GCC versions 4.4 and below don't support hard-fp.
++  // GCC versions 4.5 may support hard-fp without defining __ARM_PCS or
++  // __ARM_PCS_VFP.
++
++#define GCC_VERSION (__GNUC__ * 10000                                          \
++                     + __GNUC_MINOR__ * 100                                    \
++                     + __GNUC_PATCHLEVEL__)
++#if GCC_VERSION >= 40600
++#if defined(__ARM_PCS_VFP)
++  return true;
++#else
++  return false;
++#endif
++
++#elif GCC_VERSION < 40500
++  return false;
++
++#else
++#if defined(__ARM_PCS_VFP)
++  return true;
++#elif defined(__ARM_PCS) || defined(__SOFTFP__) || defined(__SOFTFP) || \
++      !defined(__VFP_FP__)
++  return false;
++#else
++#error "Your version of GCC does not report the FP ABI compiled for."          \
++       "Please report it on this issue"                                        \
++       "http://code.google.com/p/v8/issues/detail?id=2140"
++
++#endif
++#endif
++#undef GCC_VERSION
++}
++
++#endif  // def __arm__
++
+ 
+ const char* OS::LocalTimezone(double time, TimezoneCache* cache) {
+   if (std::isnan(time)) return "";

--- a/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_v8_src_base_platform_platform-posix.cc
+++ b/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_v8_src_base_platform_platform-posix.cc
@@ -1,0 +1,39 @@
+$NetBSD: patch-deps_v8_src_base_platform_platform-posix.cc,v 1.3 2015/09/09 00:04:54 ryoon Exp $
+
+Use sysconf(_SC_THREAD_STACK_MIN) instead of PTHREAD_STACK_MIN.
+Cast explicitly.
+
+--- deps/v8/src/base/platform/platform-posix.cc.orig	2015-09-08 15:30:38.000000000 +0000
++++ deps/v8/src/base/platform/platform-posix.cc
+@@ -329,6 +329,8 @@ int OS::GetCurrentThreadId() {
+   return static_cast<int>(syscall(__NR_gettid));
+ #elif V8_OS_ANDROID
+   return static_cast<int>(gettid());
++#elif V8_OS_NETBSD || V8_OS_FREEBSD
++  return static_cast<int>(reinterpret_cast<intptr_t>(pthread_self()));
+ #elif V8_OS_AIX
+   return static_cast<int>(thread_self());
+ #elif V8_OS_SOLARIS
+@@ -535,8 +537,13 @@ Thread::Thread(const Options& options)
+     : data_(new PlatformData),
+       stack_size_(options.stack_size()),
+       start_semaphore_(NULL) {
++#if defined(__NetBSD__)
++  if (stack_size_ > 0 && static_cast<size_t>(stack_size_) < sysconf(_SC_THREAD_STACK_MIN)) {
++    stack_size_ = sysconf(_SC_THREAD_STACK_MIN);
++#else
+   if (stack_size_ > 0 && static_cast<size_t>(stack_size_) < PTHREAD_STACK_MIN) {
+     stack_size_ = PTHREAD_STACK_MIN;
++#endif
+   }
+   set_name(options.name());
+ }
+@@ -552,7 +559,7 @@ static void SetThreadName(const char* na
+   pthread_set_name_np(pthread_self(), name);
+ #elif V8_OS_NETBSD
+   STATIC_ASSERT(Thread::kMaxThreadNameLength <= PTHREAD_MAX_NAMELEN_NP);
+-  pthread_setname_np(pthread_self(), "%s", name);
++  pthread_setname_np(pthread_self(), "%s", (void *)name);
+ #elif V8_OS_MACOSX
+   // pthread_setname_np is only available in 10.6 or later, so test
+   // for it at runtime.

--- a/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_v8_src_base_platform_semaphore.cc
+++ b/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_v8_src_base_platform_semaphore.cc
@@ -1,0 +1,26 @@
+$NetBSD: patch-deps_v8_src_base_platform_semaphore.cc,v 1.4 2015/09/09 00:04:54 ryoon Exp $
+Work around lack of sem_timedwait(3) in NetBSD < 6.99.4.
+Adapted from d4f11c0cf476dd854eaebec1cbacb1afc7bea18e of the Chromium V8 sources.
+
+--- deps/v8/src/base/platform/semaphore.cc.orig	2015-09-08 15:30:38.000000000 +0000
++++ deps/v8/src/base/platform/semaphore.cc
+@@ -11,6 +11,10 @@
+ 
+ #include <errno.h>
+ 
++#if V8_OS_NETBSD
++#include <sys/param.h>	// for __NetBSD_Version__
++#endif
++
+ #include "src/base/logging.h"
+ #include "src/base/platform/elapsed-timer.h"
+ #include "src/base/platform/time.h"
+@@ -107,7 +111,7 @@ void Semaphore::Wait() {
+ 
+ 
+ bool Semaphore::WaitFor(const TimeDelta& rel_time) {
+-#if V8_OS_NACL
++#if defined(V8_OS_NACL)  || (defined(V8_OS_NETBSD) && (__NetBSD_Version__ - 0 < 699000400))
+   // PNaCL doesn't support sem_timedwait, do ugly busy waiting.
+   ElapsedTimer timer;
+   timer.Start();

--- a/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_v8_src_log-utils.h
+++ b/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_v8_src_log-utils.h
@@ -1,0 +1,17 @@
+$NetBSD: patch-deps_v8_src_log-utils.h,v 1.1 2015/11/09 20:19:35 fhajny Exp $
+
+Need stdarg.h for va_list.
+
+--- deps/v8/src/log-utils.h.orig	2015-10-29 12:22:04.000000000 +0000
++++ deps/v8/src/log-utils.h
+@@ -9,6 +9,10 @@
+ #include "src/base/platform/mutex.h"
+ #include "src/flags.h"
+ 
++#if defined(__NetBSD__)
++#include <stdarg.h>
++#endif
++
+ namespace v8 {
+ namespace internal {
+ 

--- a/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_v8_src_types.h
+++ b/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_v8_src_types.h
@@ -1,0 +1,20 @@
+$NetBSD: patch-deps_v8_src_types.h,v 1.2 2015/11/09 20:19:35 fhajny Exp $
+
+NetBSD 6 doesn't have nearbyint.
+
+--- deps/v8/src/types.h.orig	2015-10-29 12:22:04.000000000 +0000
++++ deps/v8/src/types.h
+@@ -5,6 +5,13 @@
+ #ifndef V8_TYPES_H_
+ #define V8_TYPES_H_
+ 
++#ifdef __NetBSD__
++#include <sys/param.h>
++#if __NetBSD_Version__ - 0 < 699001700
++#define nearbyint rint
++#endif
++#endif
++
+ #include "src/conversions.h"
+ #include "src/handles.h"
+ #include "src/objects.h"

--- a/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_v8_tools_gyp_v8.gyp
+++ b/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_v8_tools_gyp_v8.gyp
@@ -1,0 +1,68 @@
+$NetBSD: patch-deps_v8_tools_gyp_v8.gyp,v 1.3 2015/09/09 00:04:54 ryoon Exp $
+
+Fix path to Python.
+
+--- deps/v8/tools/gyp/v8.gyp.orig	2015-09-08 15:30:44.000000000 +0000
++++ deps/v8/tools/gyp/v8.gyp
+@@ -1696,14 +1696,14 @@
+                       '<(PRODUCT_DIR)/natives_blob_host.bin',
+                     ],
+                     'action': [
+-                      'python', '<@(_inputs)', '<(PRODUCT_DIR)/natives_blob_host.bin'
++                      'python', '<@(_inputs)', '<(PRODUCT_DIR)/natives_blob_host.bin'
+                     ],
+                   }, {
+                     'outputs': [
+                       '<(PRODUCT_DIR)/natives_blob.bin',
+                     ],
+                     'action': [
+-                      'python', '<@(_inputs)', '<(PRODUCT_DIR)/natives_blob.bin'
++                      'python', '<@(_inputs)', '<(PRODUCT_DIR)/natives_blob.bin'
+                     ],
+                   }],
+                 ],
+@@ -1712,7 +1712,7 @@
+                   '<(PRODUCT_DIR)/natives_blob.bin',
+                 ],
+                 'action': [
+-                  'python', '<@(_inputs)', '<(PRODUCT_DIR)/natives_blob.bin'
++                  'python', '<@(_inputs)', '<(PRODUCT_DIR)/natives_blob.bin'
+                 ],
+               }],
+             ],
+@@ -1812,7 +1812,7 @@
+             '<(SHARED_INTERMEDIATE_DIR)/libraries.cc',
+           ],
+           'action': [
+-            'python',
++            'python',
+             '../../tools/js2c.py',
+             '<(SHARED_INTERMEDIATE_DIR)/libraries.cc',
+             'CORE',
+@@ -1838,7 +1838,7 @@
+             '<(SHARED_INTERMEDIATE_DIR)/experimental-libraries.cc',
+           ],
+           'action': [
+-            'python',
++            'python',
+             '../../tools/js2c.py',
+             '<(SHARED_INTERMEDIATE_DIR)/experimental-libraries.cc',
+             'EXPERIMENTAL',
+@@ -1863,7 +1863,7 @@
+             '<(SHARED_INTERMEDIATE_DIR)/extras-libraries.cc',
+           ],
+           'action': [
+-            'python',
++            'python',
+             '../../tools/js2c.py',
+             '<(SHARED_INTERMEDIATE_DIR)/extras-libraries.cc',
+             'EXTRAS',
+@@ -1900,7 +1900,7 @@
+               '<(SHARED_INTERMEDIATE_DIR)/debug-support.cc',
+             ],
+             'action': [
+-              'python',
++              'python',
+               '../../tools/gen-postmortem-metadata.py',
+               '<@(_outputs)',
+               '<@(heapobject_files)'

--- a/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_v8_tools_run-llprof.sh
+++ b/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-deps_v8_tools_run-llprof.sh
@@ -1,0 +1,15 @@
+$NetBSD: patch-deps_v8_tools_run-llprof.sh,v 1.1 2015/04/30 15:04:56 ryoon Exp $
+
+POSIX shell portability.
+
+--- deps/v8/tools/run-llprof.sh.orig	2015-03-31 22:13:01.000000000 +0000
++++ deps/v8/tools/run-llprof.sh
+@@ -46,7 +46,7 @@ framework, then calls the low level tick
+ EOF
+ }
+ 
+-if [ $# -eq 0 ] || [ "$1" == "-h" ]  || [ "$1" == "--help" ] ; then
++if [ $# -eq 0 ] || [ "$1" = "-h" ]  || [ "$1" = "--help" ] ; then
+   usage
+   exit 1
+ fi

--- a/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-src_cares__wrap.cc
+++ b/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-src_cares__wrap.cc
@@ -1,0 +1,17 @@
+$NetBSD: patch-src_cares__wrap.cc,v 1.1 2015/04/30 15:04:56 ryoon Exp $
+
+NetBSD has no AI_V4MAPPED.
+
+--- src/cares_wrap.cc.orig	2015-03-31 22:13:01.000000000 +0000
++++ src/cares_wrap.cc
+@@ -1301,8 +1301,10 @@ static void Initialize(Handle<Object> ta
+               Integer::New(env->isolate(), AF_UNSPEC));
+   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "AI_ADDRCONFIG"),
+               Integer::New(env->isolate(), AI_ADDRCONFIG));
++#if defined(AI_V4MAPPED)
+   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "AI_V4MAPPED"),
+               Integer::New(env->isolate(), AI_V4MAPPED));
++#endif
+ 
+   Local<FunctionTemplate> aiw =
+       FunctionTemplate::New(env->isolate(), NewGetAddrInfoReqWrap);

--- a/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-tools_gyp_pylib_gyp_common.py
+++ b/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-tools_gyp_pylib_gyp_common.py
@@ -1,0 +1,16 @@
+$NetBSD: patch-tools_gyp_pylib_gyp_common.py,v 1.1 2013/05/22 15:17:07 mspo Exp $
+
+Add support for NetBSD and DragonFly.
+--- tools/gyp/pylib/gyp/common.py.orig	2013-03-28 19:07:52.000000000 +0000
++++ tools/gyp/pylib/gyp/common.py
+@@ -394,6 +394,10 @@ def GetFlavor(params):
+     return 'freebsd'
+   if sys.platform.startswith('openbsd'):
+     return 'openbsd'
++  if sys.platform.startswith('netbsd'):
++    return 'netbsd'
++  if sys.platform.startswith('dragonflybsd'):
++    return 'dragonflybsd'
+   if sys.platform.startswith('aix'):
+     return 'aix'
+ 

--- a/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-tools_gyp_pylib_gyp_generator_make.py
+++ b/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-tools_gyp_pylib_gyp_generator_make.py
@@ -1,0 +1,25 @@
+$NetBSD: patch-tools_gyp_pylib_gyp_generator_make.py,v 1.3 2013/12/12 11:52:37 jperkin Exp $
+
+Add support for NetBSD and DragonFly.
+Ensure we use the system libtool on OSX.
+
+--- tools/gyp/pylib/gyp/generator/make.py.orig	2013-12-12 05:20:06.000000000 +0000
++++ tools/gyp/pylib/gyp/generator/make.py
+@@ -174,7 +174,7 @@ cmd_solink_module = $(LINK.$(TOOLSET)) -
+ 
+ LINK_COMMANDS_MAC = """\
+ quiet_cmd_alink = LIBTOOL-STATIC $@
+-cmd_alink = rm -f $@ && ./gyp-mac-tool filter-libtool libtool $(GYP_LIBTOOLFLAGS) -static -o $@ $(filter %.o,$^)
++cmd_alink = rm -f $@ && ./gyp-mac-tool filter-libtool /usr/bin/libtool $(GYP_LIBTOOLFLAGS) -static -o $@ $(filter %.o,$^)
+ 
+ quiet_cmd_link = LINK($(TOOLSET)) $@
+ cmd_link = $(LINK.$(TOOLSET)) $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -o "$@" $(LD_INPUTS) $(LIBS)
+@@ -2012,7 +2012,7 @@ def GenerateOutput(target_list, target_d
+         'flock': './gyp-flock-tool flock',
+         'flock_index': 2,
+     })
+-  elif flavor == 'freebsd':
++  elif flavor == 'freebsd' or flavor == 'dragonflybsd' or flavor == 'netbsd':
+     # Note: OpenBSD has sysutils/flock. lockf seems to be FreeBSD specific.
+     header_params.update({
+         'flock': 'lockf',

--- a/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-tools_install.py
+++ b/nodejs/patches/pkgsrc/lang/nodejs/patches/patch-tools_install.py
@@ -1,0 +1,18 @@
+$NetBSD: patch-tools_install.py,v 1.3 2015/09/09 00:04:54 ryoon Exp $
+
+Install man pages under the right directory.
+
+--- tools/install.py.orig	2015-09-08 15:30:49.000000000 +0000
++++ tools/install.py
+@@ -141,9 +141,9 @@ def files(action):
+   action(['deps/v8/tools/gdbinit'], 'share/doc/node/')
+ 
+   if 'freebsd' in sys.platform or 'openbsd' in sys.platform:
+-    action(['doc/node.1'], 'man/man1/')
++    action(['doc/node.1'], '@PKGMANDIR@/man1/')
+   else:
+-    action(['doc/node.1'], 'share/man/man1/')
++    action(['doc/node.1'], '@PKGMANDIR@/man1/')
+ 
+   if 'true' == variables.get('node_install_npm'): npm_files(action)
+ 

--- a/nodejs/rumpmain.js
+++ b/nodejs/rumpmain.js
@@ -1,1 +1,1 @@
-console.log("Hello, Rump!!");
+default.js


### PR DESCRIPTION
Support different Node versions
When bundling applications, make the Node binary filename reflect the bundled filename
