### PR TITLE
Added HTTP Rewrite Module to NGINX

### DIFF
--- a/nginx/Makefile
+++ b/nginx/Makefile
@@ -45,7 +45,6 @@ NGINX_CONF_OPTS += \
 	--http-fastcgi-temp-path=/tmp/fastcgi \
 	--http-scgi-temp-path=/tmp/scgi \
 	--http-uwsgi-temp-path=/tmp/uwsgi \
-	--without-http_rewrite_module \
 	--with-http_ssl_module \
 	--with-ipv6 \
 	--with-pcre


### PR DESCRIPTION
Added HTTP Rewrite module to NGINX which is possible since PCRE was added in an earlier commit which is a requirement for the module.
