### PR TITLE
Changed genisoimage call for Mac OS X support

### DIFF
--- a/redis/Makefile
+++ b/redis/Makefile
@@ -19,7 +19,7 @@ build/Makefile:
 	(cd build && tar -xz --strip-components 1 -f redis.tar.gz)
 
 images/data.iso: images/data/conf/*
-	genisoimage -l -r -o $@ images/data
+	$(RUMPRUN_GENISOIMAGE) -o $@ images/data
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Changed genisoimage call to $(RUMPRUN_GENISOIMAGE) for Mac OS X support added
through 92c35b8a0d3 commit.
