### PR TITLE
Update Rust to 1.9.0-dev and cargo to 0.9.0

### DIFF
--- a/rust/Makefile
+++ b/rust/Makefile
@@ -1,12 +1,9 @@
 include ../Makefile.inc
 RUST_GIT=https://github.com/rust-lang/rust.git
-RUST_VER=c9c79084
+RUST_VER=b9e61c9 # 1.9.0-dev
 
 CARGO_GIT=https://github.com/rust-lang/cargo.git
-CARGO_VER=0.5.0
-
-CARGO_RUMPBAKE_GIT=https://github.com/gandro/cargo-rumpbake.git
-CARGO_RUMPBAKE_VER=0.5.0
+CARGO_VER=0.9.0
 
 ifneq (x86_64-rumprun-netbsd,$(RUMPRUN_TOOLCHAIN_TUPLE))
 $(error Rust currently only supports x86_64-rumprun-netbsd)
@@ -15,7 +12,9 @@ endif
 RUST_DESTDIR ?= $(abspath build/destdir)
 CARGO_HOME := $(RUST_DESTDIR)/cargo
 
-all: rust cargo cargo-rumpbake
+all:
+	$(MAKE) rust
+	$(MAKE) cargo
 
 ######################################################################
 # rust - The Rust compiler and standard library
@@ -76,31 +75,11 @@ build/cargo/configure:
 	mkdir -p build
 	(cd build && git clone --branch $(CARGO_VER) $(CARGO_GIT))
 
-######################################################################
-# cargo-rumpbake - Cargo subcommand for invoking rumpbake
-######################################################################
-
-.PHONY: cargo-rumpbake
-cargo-rumpbake: build/cargo-rumpbake.stamp
-
-build/cargo-rumpbake.stamp: build/cargo-rumpbake/Cargo.toml build/cargo.stamp rustenv.sh
-	(cd build/cargo-rumpbake && \
-		sh -c '. ../../rustenv.sh && cargo build')
-	cp build/cargo-rumpbake/target/debug/cargo-rumpbake \
-		$(RUST_DESTDIR)/bin/cargo-rumpbake
-	touch $@
-
-build/cargo-rumpbake/Cargo.toml:
-	mkdir -p build
-	(cd build && \
-		git clone --branch $(CARGO_RUMPBAKE_VER) $(CARGO_RUMPBAKE_GIT))
-
 .PHONY: clean
 clean:
 	-$(MAKE) -C build/rust clean
 	-$(MAKE) -C build/cargo clean
-	rm -rf build/cargo-rumpbake/target
-	rm -f build/rust.stamp build/cargo.stamp build/cargo-rumpbake.stamp
+	rm -f build/rust.stamp build/cargo.stamp
 	rm -f rustenv.sh
 
 .PHONY: cleandir

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,15 +1,13 @@
 Overview
 ========
 
-This document explains how to build a Rust cross-compiler and the cargo package
-manager for rumprun. The Rust compiler version is a 1.5.0-dev snapshot
-(the first version that supports Rumprun), cargo and cargo-rumpbake are
-version 0.5.0.
+> Rust is a systems programming language that runs blazingly fast, prevents
+> segfaults, and guarantees thread safety.
+>                              — [rust-lang.org](https://www.rust-lang.org)
 
-This package also fetches and builds a copy of
-[cargo-rumpbake](https://github.com/gandro/cargo-rumpbake), a small wrapper
-around `cargo build` and `rumprun-bake` which simplifies building and baking when
-using `cargo` as a build tool.
+This document explains how to build a Rust cross-compiler and the cargo package
+manager for Rumprun. The Rust compiler version is a 1.9.0-dev snapshot, cargo
+is version 0.9.0.
 
 Maintainer
 ----------
@@ -21,9 +19,9 @@ Maintainer
 Instructions
 ============
 
-Running `make` will build a Rust cross-compiler for Rumprun, including the
-standard library. The cargo package manager and the cargo-rumpbake subcommand
-are also included by default. To build Rust without cargo, run `make rust`.
+Running `make` will build a Rust cross-compiler and the Rust standard library
+for Rumprun. The cargo package manager is also included by the default target.
+To build Rust without cargo, run `make rust`.
 
 Make sure the `bin` folder of your Rumprun destdir is in `$PATH`.
 
@@ -76,16 +74,18 @@ If you don't have a display attached, you can run:
 
 to have `qemu` display output on your terminal instead.
 
-### cargo rumpbake
+### Using cargo
 
-When building with cargo, you can use `cargo rumpbake`, a tool which invokes
-rumpbake automatically. To build the example TCP/IP server, proceed as follows:
+When building with cargo, you need to specify the `--target` flag as well. The
+generated binary in the target directory needs to be baked as usual.
+To build the example TCP/IP server with cargo, proceed as follows:
 
     cd examples/hello-tcp
-    cargo rumpbake hw_virtio
+    cargo build --target=x86_64-rumprun-netbsd
+    rumprun-bake hw_virtio hello-tcp.img target/x86_64-rumprun-netbsd/debug/hello-tcp
 
-This will build and bake a `hello-tcp.img` unikernel image. To run it, make sure
-you configure the network correctly. For example on Linux:
+This will build and bake a `hello-tcp.img` unikernel image. To run the binary,
+make sure to configure the network correctly. For example on Linux:
 
     sudo ip tuntap add tap0 mode tap
     sudo ip addr add 10.0.23.2/24 dev tap0


### PR DESCRIPTION
This updates Rust to a more recent version which is basically identical to the 1.8 beta, I just missed the beta window by a couple of days. I had to submit a few patches upstream to get Rust building again, but thanks to rust-lang/libc#76, Rust's libc bindings in this version have now been continuously tested. 

As discussed, I also removed `cargo rumpbake` from the Makefile and updated the README accordingly. If someone still really wants to use it, it can as always be built independently.
