### PR TITLE
add -r option to genisomage in Makefiles (nginx, haproxy)

### DIFF
--- a/haproxy/Makefile
+++ b/haproxy/Makefile
@@ -35,7 +35,7 @@ bake_hw_generic: all
 	rumprun-bake hw_generic $(HAPROXY_BIN).bin $(HAPROXY_BIN)
 
 images/$(ISO) :
-	$(RUMPRUN_GENISOIMAGE) -o images/$(ISO) images/conf
+	$(RUMPRUN_GENISOIMAGE) -r -o images/$(ISO) images/conf
 
 .PHONY: run
 run: all bake_hw_generic images/$(ISO)

--- a/nginx/Makefile
+++ b/nginx/Makefile
@@ -68,7 +68,7 @@ build/configure: | dl/$(TARBALL)
 images: images/data.iso
 
 images/data.iso: images/data/conf/* images/data/www/*
-	$(RUMPRUN_GENISOIMAGE) -o images/data.iso images/data
+	$(RUMPRUN_GENISOIMAGE) -r -o images/data.iso images/data
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Without `-r` option filenames in generated *.iso were truncated (e.g. `nginx.con` instead of `nginx.conf`...).
