### PR TITLE
tor: Fix travis build

### DIFF
--- a/tor/Makefile
+++ b/tor/Makefile
@@ -16,12 +16,13 @@ build/tor: build/Makefile
 TOR_CONF_OPTS += \
 	--prefix=$(RUMPRUN_PKGS_DIR) \
 	--disable-asciidoc \
+	--disable-systemd \
 	--enable-static-libevent \
-	--with-libevent-dir=$(shell pwd)/../../pkgs \
+	--with-libevent-dir=$(RUMPRUN_PKGS_DIR) \
 	--enable-static-openssl \
-	--with-openssl-dir=$(shell pwd)/../../pkgs \
+	--with-openssl-dir=$(RUMPRUN_SYSROOT) \
 	--enable-static-zlib \
-	--with-zlib-dir=$(shell pwd)/../../pkgs \
+	--with-zlib-dir=$(RUMPRUN_SYSROOT) \
 	--enable-static-tor
 
 build/Makefile: build/configure


### PR DESCRIPTION
This hopefully fixes the Travis build mentioned in #102, the current path not only is evaluated at the wrong time for me, but `$(RUMPRUN_PKGS_DIR)` also doesn't contain openssl and zlib. This builds locally for me, let's see what Travis says. I also had to manually disable the systemd auto-detection, it seems to be broken.

@anttikantee Would it be possible to enable Travis on pull requests? If I'm not mistaken, there should be an option for this somewhere. Would make things easier.

No fix for the `sudo` issue yet, though.
