### PR TITLE
Add python-six dependency to travis-install script

### DIFF
--- a/.travis-install.sh
+++ b/.travis-install.sh
@@ -5,6 +5,14 @@ sudo apt-get update
 sudo apt-get install makefs
 sudo apt-get install openjdk-7-jdk
 
+# ovs: python-six
+sudo apt-get install python-pip
+sudo pip install six --upgrade
+
+#debug data, please ignore
+python -c 'import six'
+echo $?
+
 # Build and install rumprun toolchain from source
 RUMPRUN_PLATFORM=${RUMPRUN_PLATFORM:-hw}
 RUMPRUN_TOOLCHAIN_TUPLE=${RUMPRUN_TOOLCHAIN_TUPLE:-x86_64-rumprun-netbsd}


### PR DESCRIPTION
Builds [#1037](https://travis-ci.org/rumpkernel/rumprun-packages/builds/253061838) to [#1043](https://travis-ci.org/rumpkernel/rumprun-packages/builds/254064676) have been failing because of a missing python library required to build ovs ("python-six").

I'm trying to fix that issue, by explicitly installing python-six before building the packages.
