### PR TITLE
travis: temporarily disable OVS tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,8 @@ env:
     - PACKAGE=apache2
     - PACKAGE=libffi
     - PACKAGE=openjdk8
-    - PACKAGE=ovs
+  # broken: issue #140
+  #  - PACKAGE=ovs
     - PACKAGE=zeromq
   #  - PACKAGE=servus
   #  - PACKAGE=zerobuf


### PR DESCRIPTION
As suggested in pull-request #139 , I disabled the OVS tests for now, and raised a new ticket (#140).
Sometimes this week I'll investigate further why the python2 interpreter behaves this way.