### PR TITLE
switch UPSTREAM to ftp.pcre.org.  ftp.csx.cam.ac.uk is gone.

### DIFF
--- a/pcre/Makefile
+++ b/pcre/Makefile
@@ -1,5 +1,5 @@
 include ../Makefile.inc
-UPSTREAM=ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.40.tar.gz
+UPSTREAM=https://ftp.pcre.org/pub/pcre/pcre-8.40.tar.gz
 TARBALL=$(notdir $(UPSTREAM))
 
 all: bin/pcre


### PR DESCRIPTION
I'm tired of the constant notifications of build failures.
